### PR TITLE
Standardize Makefile for package installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,16 @@
 BINARY_NAME := alpine
-PREFIX := /usr/local
+PREFIX = /usr/local
 bindir = $(DESTDIR)$(PREFIX)/bin
 
-linux:
+bin/$(BINARY_NAME):
 	@echo "Building ..."
 	go clean
 	go get
-	@GOOS=linux go build -ldflags=$(GO_LDFLAGS) -o bin/$(BINARY_NAME) *.go
-	@echo "Installing ..."
-ifneq ("$(wildcard $($(bindir)/alpine))","")
-	sudo rm $(bindir)/alpine
-endif
-	sudo cp -f bin/alpine $(bindir)
-	@echo "macpine installed"
+	go build -ldflags=$(GO_LDFLAGS) -o $@ *.go
 
-darwin: 
-	@echo "Building ..."
-	go clean
-	go get
-	@GOOS=darwin go build -ldflags=$(GO_LDFLAGS) -o bin/$(BINARY_NAME) *.go
+.PHONY: install
+install: bin/$(BINARY_NAME)
 	@echo "Installing ..."
-ifneq ("$(wildcard $($(bindir)/alpine))","")
-	sudo rm $(bindir)/alpine
-endif
-	sudo cp -f bin/alpine $(destdir)
+	install -d $(bindir)
+	install -m 0755 $^ $(bindir)
 	@echo "macpine installed"


### PR DESCRIPTION
Follow up to #38. My goal is to package macpine for Homebrew, and these are the changes I've made to make that possible:

* Create a target for the output binary. This is used as a prerequisite for the
  'install' target
* Create an 'install' target to create the target directory and copy the built
  executable to that directory
* Do not use 'sudo' when installing the binary (if needed, the user should use
  'sudo make install', but not all installations require 'sudo' so it should
  not be used in the Makefile directly)
* Consolidate the 'linux' and 'darwin' targets. Go can automatically detect
  which OS it is running on and needs to build for. If cross-compilation is
  needed, GOOS can be specified when running make:

      make GOOS=linux
