### PR TITLE
Add documentation for `completion`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ VMs can be easily packaged for export and re-use as tar.gz files:
 ```bash
 alpine list
 
-NAME                STATUS      SSH    PORTS ARCH        PID 
+NAME                STATUS      SSH    PORTS ARCH        PID
 forthright-hook     Running     23           aarch64     91598
 hot-cow             Running     22           x86_64      82361
 ```
@@ -132,9 +132,13 @@ Available Commands:
   ssh         Attach an interactive shell to an instance.
   start       Start an instance.
   stop        Stop an instance.
+  completion  Generate shell command completion file.
 
 Flags:
   -h, --help   help for alpine
 
 Use "alpine [command] --help" for more information about a command.
 ```
+
+Shell command completion files can be generated with `alpine completion [bash|zsh|fish|powershell]`.
+See `alpine completion -h` or the [completion documentation](docs/docs/completions.md) for more information.

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -9,13 +9,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const longCompletion = `Generate shell autocompletions. Valid arguments are bash, zsh, and fish.`
+const longCompletion = `Generate shell autocompletions. Valid arguments are bash, fish, zsh, and powershell.`
 
 var (
 	// Todo --noDesc param?
 	noDesc = false
 
-	shells = []string{"bash", "zsh", "fish", "powershell"}
+	shells = []string{"bash", "fish", "zsh", "powershell"}
 
 	// completionCmd creates completion shell files
 	completionCmd = &cobra.Command{
@@ -26,7 +26,7 @@ var (
 		DisableFlagsInUseLine: true,
 		ValidArgs:             shells,
 		Run:                   completion,
-		Hidden:                true,
+		Hidden:                false,
 	}
 )
 
@@ -38,14 +38,14 @@ func completion(cmd *cobra.Command, args []string) {
 	switch args[0] {
 	case "bash":
 		cmd.Root().GenBashCompletionV2(os.Stdout, !noDesc)
+	case "fish":
+		cmd.Root().GenFishCompletion(os.Stdout, !noDesc)
 	case "zsh":
 		if noDesc {
 			cmd.Root().GenZshCompletionNoDesc(os.Stdout)
 		} else {
 			cmd.Root().GenZshCompletion(os.Stdout)
 		}
-	case "fish":
-		cmd.Root().GenFishCompletion(os.Stdout, !noDesc)
 	case "powershell":
 		if noDesc {
 			cmd.Root().GenPowerShellCompletion(os.Stdout)

--- a/docs/docs/completions.md
+++ b/docs/docs/completions.md
@@ -6,10 +6,10 @@ You can use command `completion` command to create bash|fish|zsh|powershell comp
 alex@vosjod:~$ alpine completion
 2023/01/05 23:59:48 missing shell
 alex@vosjod:~$ alpine completion --help
-Generate shell autocompletions. Valid arguments are bash, zsh, and fish.
+Generate shell autocompletions. Valid arguments are bash, fish, zsh, and powershell.
 
 Usage:
-  alpine completion [bash|zsh|fish|powershell]
+  alpine completion [bash|fish|zsh|powershell]
 
 Flags:
   -h, --help   help for completion
@@ -37,13 +37,15 @@ __alpine_init_completion()
 
 ## Install
 
-Create completion file (bash, zsh, fish or powershell) and put on your path, for example using bash:
+Create completion file (bash, fish, zsh, or powershell) and put on your path, for example using bash:
 
 ```bash
 alex@vosjod:~$ alpine completion bash > /usr/local/etc/bash_completion.d/alpine
 alex@vosjod:~$ source /usr/local/etc/bash_completion.d/alpine
 alex@vosjod:~$
 ```
+
+For zsh, the completion file should be named `_alpine` and stored somewhere in the `$FPATH`.
 
 ## Examples
 
@@ -97,4 +99,3 @@ alex@vosjod:~$ alpine launch -a aarch64 --[tab] [tab]
 --port    (Forward VM ports to host. Multiple ports can be separated by `,`.)
 --ssh     (Forward VM SSH port to host.)
 ```
-


### PR DESCRIPTION
* Add docs to README
* Make shell list consistent everywhere (bash, fish, zsh, powershell)
* Un-hide completion command in cobra configuration
* Add zsh notes to docs/docs/completions.md and link in README

Closes #68 