### PR TITLE
Enable user-selected editor for `alpine edit`

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -14,7 +14,7 @@ import (
 // editCmd lists Alpine instances
 var editCmd = &cobra.Command{
 	Use:   "edit NAME",
-	Short: "Edit instance configuration using Vim.",
+	Short: "Edit instance configuration.",
 	Run:   edit,
 
 	ValidArgsFunction:     host.AutoCompleteVMNames,
@@ -44,26 +44,39 @@ func edit(cmd *cobra.Command, args []string) {
 
 	targetFile := filepath.Join(userHomeDir, ".macpine", args[0], "config.yaml")
 
-	if !utils.CommandExists("qemu-img") {
-		log.Fatal("vim is not available on $PATH. you can still edit config manually at " + targetFile)
-	}
+   editor, found := os.LookupEnv("EDITOR")
+   if !found || !utils.CommandExists(editor) {
+      if !found {
+         log.Print("edit: No $EDITOR set.")
+      } else {
+         log.Print("edit: $EDITOR set but not found in $PATH.")
+      }
+      if utils.CommandExists("vim") {
+         log.Print("Defaulting to \"vim\"")
+         editor = "vim"
+      } else if utils.CommandExists("nano") {
+         log.Print("Defaulting to \"nano\"")
+         editor = "nano"
+      } else {
+         log.Fatal("No basic editor found in $PATH (tried vim, nano). You can still edit the config manually at " + targetFile)
+      }
+   }
 
-	edit := run.Command("vim", targetFile)
+   edit := run.Command(editor, targetFile)
 
-	edit.Stdin = os.Stdin
-	edit.Stdout = os.Stdout
-	edit.Stderr = os.Stderr
+   edit.Stdin = os.Stdin
+   edit.Stdout = os.Stdout
+   edit.Stderr = os.Stderr
 
-	err = edit.Start()
-	if err != nil {
-		log.Fatal(err)
-	}
+   err = edit.Start()
+   if err != nil {
+      log.Fatal(err)
+   }
 
-	err = edit.Wait()
-	if err != nil {
-		log.Fatalf("error while editing. Error: %v\n", err)
-	} else {
-		log.Printf("configuration saved. restart " + args[0] + " for changes to take effect.")
-	}
-
+   err = edit.Wait()
+   if err != nil {
+      log.Fatalf("error while editing. Error: %v\n", err)
+   } else {
+      log.Printf("configuration saved. restart " + args[0] + " for changes to take effect.")
+   }
 }


### PR DESCRIPTION
* Check for $EDITOR
* If set badly, log errors
* If not set or set badly, default to vim
* If vim missing, default to nano
* Call specified editor as usual

Also fixes a bug where `alpine edit` was checking for `qemu-img` instead of `vim`. Likely an overlooked copypasta.