### PR TITLE
Fixes for Makefile behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,23 @@
 BINARY_NAME := alpine
 PREFIX = /usr/local
 bindir = $(DESTDIR)$(PREFIX)/bin
+SRCS = $(wildcard cmd/*.go host/*.go qemu/*.go utils/*.go)
+MAIN = main.go
 
-bin/$(BINARY_NAME):
+bin/$(BINARY_NAME): $(MAIN) $(SRCS)
 	@echo "Building ..."
 	go clean
 	go get
-	go build -ldflags=$(GO_LDFLAGS) -o $@ *.go
+	go build -ldflags=$(GO_LDFLAGS) -o $@ $<
 
-.PHONY: install
+.PHONY: install clean
 install: bin/$(BINARY_NAME)
 	@echo "Installing ..."
 	install -d $(bindir)
 	install -m 0755 $^ $(bindir)
 	@echo "macpine installed"
+
+clean:
+	@echo "Cleaning ..."
+	go clean
+	$(RM) -r bin/


### PR DESCRIPTION
* Add `MAIN` and `SRCS` variables to Makefile
* Make the build target depend on `MAIN` and `SRCS`
* Add `clean` target for convenience

Now, if `main.go` or any `.go` file in `cmd/`, `host/`, `qemu/`, or `utils/` changes, `make` will detect that `bin/alpine` is out of date and should be recompiled.