### PR TITLE
Fix non-root-ssh issues with `Exec` (and `Start`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,12 @@ Use "alpine [command] --help" for more information about a command.
 
 Shell command completion files can be generated with `alpine completion [bash|zsh|fish|powershell]`.
 See `alpine completion -h` or the [completion documentation](docs/docs/completions.md) for more information.
+
+## Troubleshooting
+
+To solve some common issues:
+* Ensure `PermitRootLogin yes` remains set in `/etc/ssh/sshd_config` (in the VM) or the machine may become inaccessible/fail to start.
+* If a custom root password (e.g. `pass`) is set (in the VM), add `rootpassword: pass` in `config.yaml` via `alpine edit machine-name`
+  or directly with any text editor.
+* If `alpine list` reports a machine is `Running` but the process has been terminated/killed, deleting the PID file at
+  `~/.macpine/machine-name/alpine.pid` may resolve the issue.

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -20,7 +20,7 @@ var (
 	// completionCmd creates completion shell files
 	completionCmd = &cobra.Command{
 		Use:                   fmt.Sprintf("completion [%s]", strings.Join(shells, "|")),
-		Short:                 "Generate shell autocompletions",
+		Short:                 "Generate shell autocompletions.",
 		Long:                  longCompletion,
 		DisableSuggestions:    false,
 		DisableFlagsInUseLine: true,

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -11,7 +11,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var deleteCmd = &cobra.Command{

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -11,7 +11,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // execCmd executes command on alpine vm

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -10,7 +10,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // importCmd iports an Alpine VM from file

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,7 +12,7 @@ import (
 	"github.com/beringresearch/macpine/host"
 	"github.com/beringresearch/macpine/qemu"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // listCmd lists Alpine instances

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -11,7 +11,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // publishCmd stops an Alpine instance

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -10,7 +10,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // shellCmd starts an Alpine instance

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,7 +10,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // startCmd starts an Alpine instance

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -12,7 +12,7 @@ golang.org/x/sys v0.0.0-20211031064116-611d5d643895 h1:iaNpwpnrgL5jzWS0vCNnfa8Hq
 golang.org/x/sys v0.0.0-20211031064116-611d5d643895/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ golang.org/x/sys v0.0.0-20211031064116-611d5d643895 h1:iaNpwpnrgL5jzWS0vCNnfa8Hq
 golang.org/x/sys v0.0.0-20211031064116-611d5d643895/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/host/exec.go
+++ b/host/exec.go
@@ -6,8 +6,7 @@ import (
 
 // Exec executes a command inside VM
 func Exec(config qemu.MachineConfig, cmd string) error {
-
-	err := config.Exec(cmd)
+	err := config.Exec(cmd, false) // false: run as default ssh user, not (necessarily) root
 	if err != nil {
 		return err
 	}

--- a/host/info.go
+++ b/host/info.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/beringresearch/macpine/qemu"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func Info(vmName string) (string, error) {

--- a/qemu/ops.go
+++ b/qemu/ops.go
@@ -21,40 +21,35 @@ import (
 )
 
 type MachineConfig struct {
-	Alias        string `yaml:"alias"`
-	Image        string `yaml:"image"`
-	Arch         string `yaml:"arch"`
-	CPU          string `yaml:"cpu"`
-	Memory       string `yaml:"memory"`
-	Disk         string `yaml:"disk"`
-	Mount        string `yaml:"mount"`
-	Port         string `yaml:"port"`
-	SSHPort      string `yaml:"sshport"`
-	SSHUser      string `yaml:"sshuser"`
-	SSHPassword  string `yaml:"sshpassword"`
-   RootPassword *string `yaml:"rootpassword,omitempty"` // nil if not specified
-	MACAddress   string `yaml:"macaddress"`
-	Location     string `yaml:"location"`
+	Alias        string  `yaml:"alias"`
+	Image        string  `yaml:"image"`
+	Arch         string  `yaml:"arch"`
+	CPU          string  `yaml:"cpu"`
+	Memory       string  `yaml:"memory"`
+	Disk         string  `yaml:"disk"`
+	Mount        string  `yaml:"mount"`
+	Port         string  `yaml:"port"`
+	SSHPort      string  `yaml:"sshport"`
+	SSHUser      string  `yaml:"sshuser"`
+	SSHPassword  string  `yaml:"sshpassword"`
+	RootPassword *string `yaml:"rootpassword,omitempty"` // nil if not specified
+	MACAddress   string  `yaml:"macaddress"`
+	Location     string  `yaml:"location"`
 }
 
 // Exec starts an interactive shell terminal in VM
-func (c *MachineConfig) Exec(cmd string, root ...bool) error {
-   privileged := false
-   if len(root) > 0 { // if variadic bool argument provided...
-      privileged = root[0] // ...use it, as Go doesn't support default params
-   }
-
+func (c *MachineConfig) Exec(cmd string, root bool) error {
 	host := "localhost:" + c.SSHPort
-   user := c.SSHUser
-   pwd := c.SSHPassword
-   if privileged && user != "root" {
-      user = "root"
-      if c.RootPassword == nil {
-         pwd = "root"
-      } else {
-         pwd = *c.RootPassword
-      }
-   }
+	user := c.SSHUser
+	pwd := c.SSHPassword
+	if root && user != "root" {
+		user = "root"
+		if c.RootPassword == nil {
+			pwd = "root"
+		} else {
+			pwd = *c.RootPassword
+		}
+	}
 
 	var err error
 
@@ -178,8 +173,8 @@ func (c *MachineConfig) Status() (string, int) {
 // Stop stops an Alpine VM
 func (c *MachineConfig) Stop() error {
 	pidFile := filepath.Join(c.Location, "alpine.pid")
-   // qemu creates PID file with -pidfile flag, and deletes it on sigterm
-   // TODO check if removed on sigkill
+	// qemu creates PID file with -pidfile flag, and deletes it on sigterm
+	// TODO check if removed on sigkill
 	if _, err := os.Stat(pidFile); err == nil {
 
 		_, pid := c.Status()
@@ -352,7 +347,7 @@ func (c *MachineConfig) Start() error {
 		return nil
 	})
 	if err != nil {
-      c.CleanPIDFile()
+		c.CleanPIDFile()
 		return errors.New("unable to sync clocks: " + err.Error())
 	}
 
@@ -366,7 +361,7 @@ func (c *MachineConfig) Start() error {
 		})
 
 		if err != nil {
-         c.CleanPIDFile()
+			c.CleanPIDFile()
 			return errors.New("unable to mount: " + err.Error())
 		}
 
@@ -375,7 +370,7 @@ func (c *MachineConfig) Start() error {
 
 	status, _ := c.Status()
 	if status == "Stopped" {
-      c.CleanPIDFile()
+		c.CleanPIDFile()
 		return errors.New("unable to start vm")
 	}
 
@@ -497,7 +492,7 @@ func (c *MachineConfig) Launch() error {
 			return errors.New("error expanding disk: " + err.Error())
 		}
 
-		err = c.Exec("df -h")
+		err = c.Exec("df -h", false)
 		if err != nil {
 			return err
 		}
@@ -549,7 +544,7 @@ func (c *MachineConfig) CreateQemuDiskImage(imageName string) error {
 
 func (c *MachineConfig) CleanPIDFile() {
 	pidFile := filepath.Join(c.Location, "alpine.pid")
-   if err := os.Remove(pidFile); err != nil && !errors.Is(err, os.ErrNotExist) {
-      log.Fatalf("Error deleting pidfile at %s. Manually delete it before proceeding.", pidFile)
-   }
+	if err := os.Remove(pidFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Fatalf("Error deleting pidfile at %s. Manually delete it before proceeding.", pidFile)
+	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -41,7 +41,6 @@ func Retry(attempts int, sleep time.Duration, f func() error) (err error) {
 		if i > 0 {
 			fmt.Printf("\r%s", strings.Repeat(".", i))
 			time.Sleep(sleep)
-			sleep *= 2
 		}
 		err = f()
 		if err == nil {


### PR DESCRIPTION
Closes #67, refer to that issue for discussion of changes.

* Bump yaml to v3
* Add optional (`omitempty`) `rootpassword` field to `config.yaml`
* Add optional (variadic) argument to `Exec()` to run as root
* Read `config.yaml` for root password, or use default
* Add comment that `qemu-system-...` creates/deletes the pidfile with
  `-pidfile`
* Change retry counters/thresholds to avoid >30 seconds retrying
* Lengthen retry times for i/o operations as they may take longer
* use `Exec("...", true)` to run various mgmt commands as root
* Add `CleanPIDFile` function if `qemu` command succeeds but `Start`
  fails
* Add troubleshooting docs in README