### PR TITLE
Go scorecard complained about `cmd/edit.go`

### DIFF
--- a/.github/workflows/goscorecard.yml
+++ b/.github/workflows/goscorecard.yml
@@ -1,0 +1,2 @@
+- name: Go report card
+  uses: creekorful/goreportcard-action@v1.0

--- a/.github/workflows/goscorecard.yml
+++ b/.github/workflows/goscorecard.yml
@@ -1,11 +1,11 @@
 name: Go report card
 
 on:
-  - push:
+  push:
       branches: [ "main" ]
-  - pull_request:
+  pull_request:
       branches: [ "main" ]
-  - workflow_dispatch
+  workflow_dispatch
 
 jobs:
   refresh-scorecard:

--- a/.github/workflows/goscorecard.yml
+++ b/.github/workflows/goscorecard.yml
@@ -5,7 +5,7 @@ on:
       branches: [ "main" ]
   pull_request:
       branches: [ "main" ]
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   refresh-scorecard:

--- a/.github/workflows/goscorecard.yml
+++ b/.github/workflows/goscorecard.yml
@@ -2,7 +2,7 @@ name: Go report card
 
 on:
   push:
-      branches: [ "main" ]
+      branches: [ "main", "go-fmt-edits" ]
   pull_request:
       branches: [ "main" ]
   workflow_dispatch:

--- a/.github/workflows/goscorecard.yml
+++ b/.github/workflows/goscorecard.yml
@@ -1,2 +1,13 @@
-- name: Go report card
-  uses: creekorful/goreportcard-action@v1.0
+name: Go report card
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  refresh-scorecard:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: creekorful/goreportcard-action@v1.0

--- a/.github/workflows/goscorecard.yml
+++ b/.github/workflows/goscorecard.yml
@@ -1,10 +1,11 @@
 name: Go report card
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  - push:
+      branches: [ "main" ]
+  - pull_request:
+      branches: [ "main" ]
+  - workflow_dispatch
 
 jobs:
   refresh-scorecard:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY_NAME := alpine
 PREFIX = /usr/local
 bindir = $(DESTDIR)$(PREFIX)/bin
-SRCS = $(wildcard cmd/*.go host/*.go qemu/*.go utils/*.go)
+SRCS = $(wildcard */*.go)
 MAIN = main.go
 
 bin/$(BINARY_NAME): $(MAIN) $(SRCS)
@@ -10,7 +10,7 @@ bin/$(BINARY_NAME): $(MAIN) $(SRCS)
 	go get
 	go build -ldflags=$(GO_LDFLAGS) -o $@ $<
 
-.PHONY: install clean
+.PHONY: install clean fmt
 install: bin/$(BINARY_NAME)
 	@echo "Installing ..."
 	install -d $(bindir)
@@ -21,3 +21,6 @@ clean:
 	@echo "Cleaning ..."
 	go clean
 	$(RM) -r bin/
+
+fmt:
+	@gofmt -e -l -s -w $(MAIN) $(SRCS)

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -44,39 +44,39 @@ func edit(cmd *cobra.Command, args []string) {
 
 	targetFile := filepath.Join(userHomeDir, ".macpine", args[0], "config.yaml")
 
-   editor, found := os.LookupEnv("EDITOR")
-   if !found || !utils.CommandExists(editor) {
-      if !found {
-         log.Println("edit: No $EDITOR set.")
-      } else {
-         log.Println("edit: $EDITOR set but not found in $PATH.")
-      }
-      if utils.CommandExists("vim") {
-         log.Println("defaulting to \"vim\"")
-         editor = "vim"
-      } else if utils.CommandExists("nano") {
-         log.Println("defaulting to \"nano\"")
-         editor = "nano"
-      } else {
-         log.Fatal("no basic editor found in $PATH (tried vim, nano). You can still edit the config manually at " + targetFile)
-      }
-   }
+	editor, found := os.LookupEnv("EDITOR")
+	if !found || !utils.CommandExists(editor) {
+		if !found {
+			log.Println("edit: No $EDITOR set.")
+		} else {
+			log.Println("edit: $EDITOR set but not found in $PATH.")
+		}
+		if utils.CommandExists("vim") {
+			log.Println("defaulting to \"vim\"")
+			editor = "vim"
+		} else if utils.CommandExists("nano") {
+			log.Println("defaulting to \"nano\"")
+			editor = "nano"
+		} else {
+			log.Fatal("no basic editor found in $PATH (tried vim, nano). You can still edit the config manually at " + targetFile)
+		}
+	}
 
-   edit := run.Command(editor, targetFile)
+	edit := run.Command(editor, targetFile)
 
-   edit.Stdin = os.Stdin
-   edit.Stdout = os.Stdout
-   edit.Stderr = os.Stderr
+	edit.Stdin = os.Stdin
+	edit.Stdout = os.Stdout
+	edit.Stderr = os.Stderr
 
-   err = edit.Start()
-   if err != nil {
-      log.Fatal(err)
-   }
+	err = edit.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-   err = edit.Wait()
-   if err != nil {
-      log.Fatalf("error while editing. Error: %v\n", err)
-   } else {
-      log.Printf("configuration saved. restart " + args[0] + " for changes to take effect.")
-   }
+	err = edit.Wait()
+	if err != nil {
+		log.Fatalf("error while editing. Error: %v\n", err)
+	} else {
+		log.Printf("configuration saved. restart " + args[0] + " for changes to take effect.")
+	}
 }


### PR DESCRIPTION
* Run `go fmt` with all flags on `cmd/edit.go`
* Add `Makefile` target `fmt` to conveniently run `gofmt`
* `fmt` target modifies files in-place
* Add a GH Action to auto-refresh the Go Scorecard