### PR TITLE
Add ':' port mapping configuration option, and briefly document in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ alpine ssh $VMNAME #attach to the VM shell
 Expose additional VM ports to host:
 
 ```bash
-alpine launch -s 23 -p 8888,5432 #launch a VM, expose SSH to host port 23 and forward VM ports 8888 and 5432 to host ports 8888 and 5432
+alpine launch -s 23 -p 8888,5432 #launch a VM, expose SSH to host port 23 and forward host ports 8888 and 5432 to VM ports 8888 and 5432
+alpine launch -s 8023 -p 8081:8082,8083 #launch a VM, expose SSH to host port 8023, forward host port 8081 to VM port 8082, and forward
+                                        #host port 8083 to VM port 8083
 ```
 
 VMs can be easily packaged for export and re-use as tar.gz files:

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -11,7 +11,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var deleteCmd = &cobra.Command{

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -11,7 +11,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // execCmd executes command on alpine vm

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -10,7 +10,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // importCmd iports an Alpine VM from file

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -97,8 +97,12 @@ func correctArguments(imageVersion string, machineArch string, machineCPU string
 	if machinePort != "" {
 		for _, p := range ports {
 			int, err = strconv.Atoi(p)
-			if err != nil || int < 0 {
-				return errors.New("port must be positive integer separated by commas without spaces")
+			if err != nil {
+            ports = strings.Split(p, ":")
+            host, herr = strconv.Atoi(ports[0])
+            guest, gerr = strconv.Atoi(ports[1])
+            if len(ports) != 2 || herr != nil || gerr != nil || int < 0 || host < 0 || guest < 0 {
+               return errors.New("port must either be positive integers (e.g. 1234) or pairs separated by ':' (e.g. 4444:5555), each separated by commas (e.g. 1234,4444:5555)")
 			}
 		}
 	}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -92,28 +92,28 @@ func correctArguments(imageVersion string, machineArch string, machineCPU string
 		return errors.New("ssh port (-s) must be a positive integer")
 	}
 
-   // TODO PortMap
+	// TODO PortMap
 	ports := strings.Split(machinePort, ",")
 
 	if machinePort != "" {
-      porterror := "port must either be positive integers (e.g. 1234) or pairs separated by ':' (e.g. 4444:5555), each separated by commas (e.g. 1234,4444:5555)"
+		porterror := "port must either be positive integers (e.g. 1234) or pairs separated by ':' (e.g. 4444:5555), each separated by commas (e.g. 1234,4444:5555)"
 		for _, p := range ports {
-         if strings.Contains(p, ":") {
-            mapping := strings.Split(p, ":")
-            if len(mapping) != 2 {
-               return errors.New(porterror)
-            }
-            in, inerr := strconv.Atoi(mapping[0])
-            out, outerr := strconv.Atoi(mapping[1])
-            if inerr != nil || outerr != nil || in < 0 || out < 0 {
-               return errors.New(porterror)
-            }
-         } else {
-            port, perr := strconv.Atoi(p)
-            if perr != nil || port < 0 {
-               return errors.New(porterror)
-            }
-         }
+			if strings.Contains(p, ":") {
+				mapping := strings.Split(p, ":")
+				if len(mapping) != 2 {
+					return errors.New(porterror)
+				}
+				in, inerr := strconv.Atoi(mapping[0])
+				out, outerr := strconv.Atoi(mapping[1])
+				if inerr != nil || outerr != nil || in < 0 || out < 0 {
+					return errors.New(porterror)
+				}
+			} else {
+				port, perr := strconv.Atoi(p)
+				if perr != nil || port < 0 {
+					return errors.New(porterror)
+				}
+			}
 		}
 	}
 

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -92,29 +92,9 @@ func correctArguments(imageVersion string, machineArch string, machineCPU string
 		return errors.New("ssh port (-s) must be a positive integer")
 	}
 
-	// TODO PortMap
-	ports := strings.Split(machinePort, ",")
-
-	if machinePort != "" {
-		porterror := "port must either be positive integers (e.g. 1234) or pairs separated by ':' (e.g. 4444:5555), each separated by commas (e.g. 1234,4444:5555)"
-		for _, p := range ports {
-			if strings.Contains(p, ":") {
-				mapping := strings.Split(p, ":")
-				if len(mapping) != 2 {
-					return errors.New(porterror)
-				}
-				in, inerr := strconv.Atoi(mapping[0])
-				out, outerr := strconv.Atoi(mapping[1])
-				if inerr != nil || outerr != nil || in < 0 || out < 0 {
-					return errors.New(porterror)
-				}
-			} else {
-				port, perr := strconv.Atoi(p)
-				if perr != nil || port < 0 {
-					return errors.New(porterror)
-				}
-			}
-		}
+	_, err = utils.ParsePort(machinePort)
+	if err != nil {
+		return err
 	}
 
 	if machineMount != "" {

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -95,15 +95,24 @@ func correctArguments(imageVersion string, machineArch string, machineCPU string
 	ports := strings.Split(machinePort, ",")
 
 	if machinePort != "" {
+      porterror := "port must either be positive integers (e.g. 1234) or pairs separated by ':' (e.g. 4444:5555), each separated by commas (e.g. 1234,4444:5555)"
 		for _, p := range ports {
-			int, err = strconv.Atoi(p)
-			if err != nil {
-            ports = strings.Split(p, ":")
-            host, herr = strconv.Atoi(ports[0])
-            guest, gerr = strconv.Atoi(ports[1])
-            if len(ports) != 2 || herr != nil || gerr != nil || int < 0 || host < 0 || guest < 0 {
-               return errors.New("port must either be positive integers (e.g. 1234) or pairs separated by ':' (e.g. 4444:5555), each separated by commas (e.g. 1234,4444:5555)")
-			}
+         if strings.Contains(p, ":") {
+            mapping := strings.Split(p, ":")
+            if len(mapping) != 2 {
+               return errors.New(porterror)
+            }
+            in, inerr := strconv.Atoi(mapping[0])
+            out, outerr := strconv.Atoi(mapping[1])
+            if inerr != nil || outerr != nil || in < 0 || out < 0 {
+               return errors.New(porterror)
+            }
+         } else {
+            port, perr := strconv.Atoi(p)
+            if perr != nil || port < 0 {
+               return errors.New(porterror)
+            }
+         }
 		}
 	}
 

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -92,6 +92,7 @@ func correctArguments(imageVersion string, machineArch string, machineCPU string
 		return errors.New("ssh port (-s) must be a positive integer")
 	}
 
+   // TODO PortMap
 	ports := strings.Split(machinePort, ",")
 
 	if machinePort != "" {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,7 +12,7 @@ import (
 	"github.com/beringresearch/macpine/host"
 	"github.com/beringresearch/macpine/qemu"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // listCmd lists Alpine instances

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -11,7 +11,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // publishCmd stops an Alpine instance

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -10,7 +10,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // shellCmd starts an Alpine instance

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,7 +10,7 @@ import (
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // startCmd starts an Alpine instance

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/spf13/cobra v1.4.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,3 +16,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -14,7 +14,6 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/host/info.go
+++ b/host/info.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/beringresearch/macpine/qemu"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func Info(vmName string) (string, error) {

--- a/host/launch.go
+++ b/host/launch.go
@@ -1,19 +1,23 @@
 package host
 
 import (
-	"strings"
-
 	"github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
+	"strconv"
 )
-
-// TODO PortMap
 
 // Launch launches a new VM using user-defined configuration
 func Launch(config qemu.MachineConfig) error {
 
-	ports := strings.Split(config.Port, ",")
-	allPorts := append([]string{config.SSHPort}, ports...)
+	ports, err := utils.ParsePort(config.Port)
+	if err != nil {
+		return err
+	}
+	hostports := make([]string, len(ports))
+	for i, p := range ports {
+		hostports[i] = strconv.Itoa(p.Host)
+	}
+	allPorts := append([]string{config.SSHPort}, hostports...)
 
 	for _, p := range allPorts {
 		err := utils.Ping("localhost", p)
@@ -22,7 +26,7 @@ func Launch(config qemu.MachineConfig) error {
 		}
 	}
 
-	err := config.Launch()
+	err = config.Launch()
 	if err != nil {
 		return err
 	}

--- a/host/launch.go
+++ b/host/launch.go
@@ -7,6 +7,8 @@ import (
 	"github.com/beringresearch/macpine/utils"
 )
 
+// TODO PortMap
+
 // Launch launches a new VM using user-defined configuration
 func Launch(config qemu.MachineConfig) error {
 

--- a/host/start.go
+++ b/host/start.go
@@ -8,6 +8,8 @@ import (
 	"github.com/beringresearch/macpine/utils"
 )
 
+// TODO PortMap
+
 // Start launches a new VM using user-defined configuration
 func Start(config qemu.MachineConfig) error {
 

--- a/host/start.go
+++ b/host/start.go
@@ -22,9 +22,9 @@ func Start(config qemu.MachineConfig) error {
 	allPorts := append([]string{config.SSHPort}, ports...)
 
 	for _, p := range allPorts {
-      if strings.Contains(p, ":") {
-         p = strings.Split(p, ":")[0]
-      }
+		if strings.Contains(p, ":") {
+			p = strings.Split(p, ":")[0]
+		}
 		err := utils.Ping("localhost", p)
 		if err != nil {
 			return err

--- a/host/start.go
+++ b/host/start.go
@@ -20,6 +20,9 @@ func Start(config qemu.MachineConfig) error {
 	allPorts := append([]string{config.SSHPort}, ports...)
 
 	for _, p := range allPorts {
+      if strings.Contains(p, ":") {
+         p = strings.Split(p, ":")[0]
+      }
 		err := utils.Ping("localhost", p)
 		if err != nil {
 			return err

--- a/host/start.go
+++ b/host/start.go
@@ -2,13 +2,12 @@ package host
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 )
-
-// TODO PortMap
 
 // Start launches a new VM using user-defined configuration
 func Start(config qemu.MachineConfig) error {
@@ -18,8 +17,15 @@ func Start(config qemu.MachineConfig) error {
 		return errors.New(config.Alias + " is already running")
 	}
 
-	ports := strings.Split(config.Port, ",")
-	allPorts := append([]string{config.SSHPort}, ports...)
+	ports, err := utils.ParsePort(config.Port)
+	if err != nil {
+		return err
+	}
+	hostports := make([]string, len(ports))
+	for i, p := range ports {
+		hostports[i] = strconv.Itoa(p.Host)
+	}
+	allPorts := append([]string{config.SSHPort}, hostports...)
 
 	for _, p := range allPorts {
 		if strings.Contains(p, ":") {
@@ -31,7 +37,7 @@ func Start(config qemu.MachineConfig) error {
 		}
 	}
 
-	err := config.Start()
+	err = config.Start()
 	if err != nil {
 		return err
 	}

--- a/qemu/ops.go
+++ b/qemu/ops.go
@@ -233,28 +233,28 @@ func (c *MachineConfig) Start() error {
 
 	exposedPorts := "user,id=net0,hostfwd=tcp::" + c.SSHPort + "-:22"
 
-   // TODO PortMap
+	// TODO PortMap
 	if c.Port != "" {
-      var host, guest string
+		var host, guest string
 		s := strings.Split(c.Port, ",")
 		for _, p := range s {
-         if strings.Contains(p, ":") {
-            ports := strings.Split(p, ":")
-            if len(ports) != 2 {
-               log.Fatal("Invalid port configuration in config.yaml")
-            }
-            host = ports[0]
-            guest = ports[1]
-         } else {
-            host = p
-            guest = p
-         }
-         if h, err := strconv.Atoi(host); err != nil || h < 0 || h >= 65536 {
-            log.Fatal("Invalid port configuration in config.yaml")
-         }
-         if g, err := strconv.Atoi(guest); err != nil || g < 0 || g >= 65536 {
-            log.Fatal("Invalid port configuration in config.yaml")
-         }
+			if strings.Contains(p, ":") {
+				ports := strings.Split(p, ":")
+				if len(ports) != 2 {
+					log.Fatal("Invalid port configuration in config.yaml")
+				}
+				host = ports[0]
+				guest = ports[1]
+			} else {
+				host = p
+				guest = p
+			}
+			if h, err := strconv.Atoi(host); err != nil || h < 0 || h >= 65536 {
+				log.Fatal("Invalid port configuration in config.yaml")
+			}
+			if g, err := strconv.Atoi(guest); err != nil || g < 0 || g >= 65536 {
+				log.Fatal("Invalid port configuration in config.yaml")
+			}
 			exposedPorts += ",hostfwd=tcp::" + host + "-:" + guest
 		}
 	}

--- a/qemu/ops.go
+++ b/qemu/ops.go
@@ -17,7 +17,7 @@ import (
 	"github.com/beringresearch/macpine/utils"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/term"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type MachineConfig struct {

--- a/qemu/ops.go
+++ b/qemu/ops.go
@@ -234,9 +234,27 @@ func (c *MachineConfig) Start() error {
 	exposedPorts := "user,id=net0,hostfwd=tcp::" + c.SSHPort + "-:22"
 
 	if c.Port != "" {
+      var host, guest string
 		s := strings.Split(c.Port, ",")
 		for _, p := range s {
-			exposedPorts += ",hostfwd=tcp::" + p + "-:" + p
+         if strings.Contains(p, ":") {
+            ports := strings.Split(p, ":")
+            if len(ports) != 2 {
+               log.Fatal("Invalid port configuration in config.yaml")
+            }
+            host = ports[0]
+            guest = ports[1]
+         } else {
+            host = p
+            guest = p
+         }
+         if h, err := strconv.Atoi(host); err != nil || h < 0 || h >= 65536 {
+            log.Fatal("Invalid port configuration in config.yaml")
+         }
+         if g, err := strconv.Atoi(guest); err != nil || g < 0 || g >= 65536 {
+            log.Fatal("Invalid port configuration in config.yaml")
+         }
+			exposedPorts += ",hostfwd=tcp::" + host + "-:" + guest
 		}
 	}
 

--- a/qemu/ops.go
+++ b/qemu/ops.go
@@ -233,6 +233,7 @@ func (c *MachineConfig) Start() error {
 
 	exposedPorts := "user,id=net0,hostfwd=tcp::" + c.SSHPort + "-:22"
 
+   // TODO PortMap
 	if c.Port != "" {
       var host, guest string
 		s := strings.Split(c.Port, ",")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -51,22 +51,25 @@ func Retry(attempts int, sleep time.Duration, f func() error) (err error) {
 	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
 }
 
-type Proto int
+type Protocol int
 
 const (
-	Tcp Proto = iota
+	Tcp Protocol = iota
 	Udp
 )
 
 type PortMap struct {
-	host  int
-	guest int
-	proto Proto
+	Host  int
+	Guest int
+	Proto Protocol
 }
 
 // Parses port mapping configurations
 func ParsePort(ports string) ([]PortMap, error) {
 	var maps []PortMap = nil
+	if ports == "" {
+		return maps, nil
+	}
 	mapcount := strings.Count(ports, ",") + 1
 	if mapcount > 65535 {
 		return nil, errors.New("Too many port mappings specified, likely an error. Check config.yaml")
@@ -76,7 +79,7 @@ func ParsePort(ports string) ([]PortMap, error) {
 		newmap := PortMap{0, 0, Tcp}
 		var herr, gerr error = nil, nil
 		if strings.HasSuffix(p, "u") {
-			newmap.proto = Udp
+			newmap.Proto = Udp
 			p = strings.TrimSuffix(p, "u")
 		}
 		if strings.Contains(p, ":") {
@@ -84,16 +87,16 @@ func ParsePort(ports string) ([]PortMap, error) {
 			if len(pair) != 2 {
 				return nil, errors.New("Incorrect port mapping pair specified. Check config.yaml")
 			}
-			newmap.host, herr = strconv.Atoi(pair[0])
-			newmap.guest, gerr = strconv.Atoi(pair[1])
+			newmap.Host, herr = strconv.Atoi(pair[0])
+			newmap.Guest, gerr = strconv.Atoi(pair[1])
 		} else {
-			newmap.host, herr = strconv.Atoi(p)
-			newmap.guest = newmap.host
+			newmap.Host, herr = strconv.Atoi(p)
+			newmap.Guest = newmap.Host
 		}
 		if herr != nil || gerr != nil {
 			return nil, errors.New("Error parsing specified ports. Check config.yaml")
 		}
-		if newmap.host < 0 || newmap.host > 65535 || newmap.guest < 0 || newmap.guest > 65535 {
+		if newmap.Host < 0 || newmap.Host > 65535 || newmap.Guest < 0 || newmap.Guest > 65535 {
 			return nil, errors.New("Invalid specified ports (must be 0-65535). Check config.yaml")
 		}
 		maps[i] = newmap

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -52,52 +52,53 @@ func Retry(attempts int, sleep time.Duration, f func() error) (err error) {
 }
 
 type Proto int
+
 const (
-   Tcp Proto = iota
-   Udp
+	Tcp Proto = iota
+	Udp
 )
 
 type PortMap struct {
-   host int
-   guest int
-   proto Proto
+	host  int
+	guest int
+	proto Proto
 }
 
 // Parses port mapping configurations
 func ParsePort(ports string) ([]PortMap, error) {
-   var maps []PortMap = nil
-   mapcount := strings.Count(ports, ",")+1
-   if mapcount > 65535 {
-      return nil, errors.New("Too many port mappings specified, likely an error. Check config.yaml")
-   }
-   maps = make([]PortMap, mapcount)
-   for i, p := range strings.Split(ports, ",") {
-      newmap := PortMap{ 0, 0, Tcp }
-      var herr, gerr error = nil, nil
-      if strings.HasSuffix(p, "u") {
-         newmap.proto = Udp
-         p = strings.TrimSuffix(p, "u")
-      }
-      if strings.Contains(p, ":") {
-         pair := strings.Split(p, ":")
-         if len(pair) != 2 {
-            return nil, errors.New("Incorrect port mapping pair specified. Check config.yaml")
-         }
-         newmap.host, herr = strconv.Atoi(pair[0])
-         newmap.guest, gerr = strconv.Atoi(pair[1])
-      } else {
-         newmap.host, herr = strconv.Atoi(p)
-         newmap.guest = newmap.host
-      }
-      if herr != nil || gerr != nil {
-         return nil, errors.New("Error parsing specified ports. Check config.yaml")
-      }
-      if newmap.host < 0 || newmap.host > 65535 || newmap.guest < 0 || newmap.guest > 65535 {
-         return nil, errors.New("Invalid specified ports (must be 0-65535). Check config.yaml")
-      }
-      maps[i] = newmap
-   }
-   return maps, nil
+	var maps []PortMap = nil
+	mapcount := strings.Count(ports, ",") + 1
+	if mapcount > 65535 {
+		return nil, errors.New("Too many port mappings specified, likely an error. Check config.yaml")
+	}
+	maps = make([]PortMap, mapcount)
+	for i, p := range strings.Split(ports, ",") {
+		newmap := PortMap{0, 0, Tcp}
+		var herr, gerr error = nil, nil
+		if strings.HasSuffix(p, "u") {
+			newmap.proto = Udp
+			p = strings.TrimSuffix(p, "u")
+		}
+		if strings.Contains(p, ":") {
+			pair := strings.Split(p, ":")
+			if len(pair) != 2 {
+				return nil, errors.New("Incorrect port mapping pair specified. Check config.yaml")
+			}
+			newmap.host, herr = strconv.Atoi(pair[0])
+			newmap.guest, gerr = strconv.Atoi(pair[1])
+		} else {
+			newmap.host, herr = strconv.Atoi(p)
+			newmap.guest = newmap.host
+		}
+		if herr != nil || gerr != nil {
+			return nil, errors.New("Error parsing specified ports. Check config.yaml")
+		}
+		if newmap.host < 0 || newmap.host > 65535 || newmap.guest < 0 || newmap.guest > 65535 {
+			return nil, errors.New("Invalid specified ports (must be 0-65535). Check config.yaml")
+		}
+		maps[i] = newmap
+	}
+	return maps, nil
 }
 
 // Ping checks if connection is reachable


### PR DESCRIPTION
Closes #77.

Now, ports can be specified as `1234` for host-to-VM forwarding (i.e. `host:1234 <-> VM:1234`) or as `2345:3456` (i.e. `host:2345 <-> VM:3456`).

`qemu/ops.go` is updated to create the correct `qemu` rules.

`cmd/launch.go` is updated to validate `-p` argument as either ports or port pairs.