### PR TITLE
Make RTC sync to system clock

### DIFF
--- a/qemu/ops.go
+++ b/qemu/ops.go
@@ -325,7 +325,7 @@ func (c *MachineConfig) Start() error {
 	}
 
 	err = utils.Retry(10, 2*time.Second, func() error {
-		err := c.Exec("hwclock -s")
+		err := c.Exec("hwclock -w")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Uses `hwclock -w` during boot up. However, the system clock may be incorrect. If corrected manually or with NTP, `hwclock -w` can be used to also correct the real-timel clock (RTC).

Closes #78 (sort of...)