### PR TITLE
Don't show 0 for PID when VM is stopped

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,7 +33,7 @@ func list(cmd *cobra.Command, args []string) {
 
 	status := []string{}
 	config := []qemu.MachineConfig{}
-	pid := []int{}
+	pid := []string{}
 
 	vmNames, err := host.ListVMNames()
 	if err != nil {
@@ -57,7 +57,11 @@ func list(cmd *cobra.Command, args []string) {
 
 		s, p := host.Status(machineConfig)
 		status = append(status, s)
-		pid = append(pid, p)
+		if s == "Stopped" {
+			pid = append(pid, "-")
+		} else {
+			pid = append(pid, fmt.Sprint(p))
+		}
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)


### PR DESCRIPTION
* change to `cmd/list.go` to show "-" for PID of Stopped instances

Just a quick vanity change. Example:

Pre-PR:
```sh
$ alpine list
NAME       OS         STATUS      SSH    PORTS ARCH        PID
test       alpine     Stopped     22           aarch64     0

```

Post-PR:
```sh
$ alpine list
NAME       OS         STATUS      SSH    PORTS ARCH        PID
test       alpine     Stopped     22           aarch64     -

```