### PR TITLE
Secure config credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+TODO
 
 bin/
 docs/site

--- a/utils/credential.go
+++ b/utils/credential.go
@@ -8,8 +8,8 @@ import (
 
 type CredentialType int
 const (
-   Password CredentialType = iota
-   Host
+   PwdCred CredentialType = iota
+   HostCred
 )
 type Credential struct {
    CRType CredentialType;
@@ -36,23 +36,23 @@ func GetCredential(config string) (Credential, error) {
    var err error = nil
    if strings.HasPrefix(config, "raw::") {
       cred.CR = strings.TrimPrefix(config, "raw::")
-      cred.CRType = Password
+      cred.CRType = PwdCred
    } else if strings.HasPrefix(config, "env::") {
       envvar := strings.TrimPrefix(config, "env::")
       val, ok := os.LookupEnv(envvar)
       if ok {
          cred.CR = val
-         cred.CRType = Password
+         cred.CRType = PwdCred
       } else {
          err = fmt.Errorf("config.yaml specifies environment variable credential but variable is not set.")
       }
    } else if strings.HasPrefix(config, "ssh::") {
       cred.CR = strings.TrimPrefix(config, "ssh::")
-      cred.CRType = Host
+      cred.CRType = HostCred
    } else {
       // likely a legacy config file with a raw password and no prefix
       cred.CR = config
-      cred.CRType = Password
+      cred.CRType = PwdCred
    }
    return cred, err
 }

--- a/utils/credential.go
+++ b/utils/credential.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type CredentialType int
+const (
+   Password CredentialType = iota
+   Host
+)
+type Credential struct {
+   CRType CredentialType;
+   CR string;
+}
+
+/* credential backends: raw, env, ssh-agent
+ * if you want to store credentials in the macOS keychain, configure your SSH agent to use the keychain
+ * - raw:         "raw::password" (password is a string directly after "pw:" prefix)
+ * - env:         "env::PASS_VAR" (password is stored in environment variable $PASS_VAR)
+ * - ssh-agent:   "ssh::HOST"     (credential is stored in ssh-agent and configured for use with host HOST in the ssh config)
+
+ * `ssh-agent` is the most secure by far, as it allows certificate-based authentication rather than using passwords.
+ * If `ssh-agent` is configured and working, `PasswordAuthentication no` can be set in `/etc/ssh/sshd_config` to significantly
+ * harden the VM.
+*/
+func GetCredential(config string) (Credential, error) {
+   var cred Credential
+   var err error = nil
+   if strings.HasPrefix(config, "raw::") {
+      cred.CR = strings.TrimPrefix(config, "raw::")
+      cred.CRType = Password
+   } else if strings.HasPrefix(config, "env::") {
+      envvar := strings.TrimPrefix(config, "env::")
+      val, ok := os.LookupEnv(envvar)
+      if ok {
+         cred.CR = val
+         cred.CRType = Password
+      } else {
+         err = fmt.Errorf("config.yaml specifies environment variable credential but variable is not set.")
+      }
+   } else if strings.HasPrefix(config, "ssh::") {
+      cred.CR = strings.TrimPrefix(config, "ssh::")
+      cred.CRType = Host
+   } else {
+      // likely a legacy config file with a raw password and no prefix
+      cred.CR = config
+      cred.CRType = Password
+   }
+   return cred, err
+}

--- a/utils/credential.go
+++ b/utils/credential.go
@@ -16,15 +16,20 @@ type Credential struct {
    CR string;
 }
 
+// TODO check for all uses of sshpassword and rootpassword to wrap with GetCredential
+
 /* credential backends: raw, env, ssh-agent
  * if you want to store credentials in the macOS keychain, configure your SSH agent to use the keychain
- * - raw:         "raw::password" (password is a string directly after "pw:" prefix)
+ * - raw:         "raw::password" (password is a string directly after "raw::" prefix)
  * - env:         "env::PASS_VAR" (password is stored in environment variable $PASS_VAR)
  * - ssh-agent:   "ssh::HOST"     (credential is stored in ssh-agent and configured for use with host HOST in the ssh config)
 
  * `ssh-agent` is the most secure by far, as it allows certificate-based authentication rather than using passwords.
- * If `ssh-agent` is configured and working, `PasswordAuthentication no` can be set in `/etc/ssh/sshd_config` to significantly
- * harden the VM.
+ * If `ssh-agent` is configured and working with certificate-based authentication, `PasswordAuthentication no` can be
+ * set in `/etc/ssh/sshd_config` to significantly harden the VM.
+ *
+ * `env` is more secure than `raw`, and may be useful for automation using macpine on systems where configuring `ssh-agent`
+ * is inconvenient.
 */
 func GetCredential(config string) (Credential, error) {
    var cred Credential


### PR DESCRIPTION
Closes #70.

Adding support for additional credential backends in `utils/credential.go`.

* Current: "raw" passwords can be formatted in `config.yaml` as `password` or as `raw::password` where the prefix denote the credential kind
* New: `env::VAR_NAME` fetches the SSH password for `root` from the host environment variables
* New: `ssh:HOST_NAME` uses `ssh-agent` to authenticate, requiring that `HOST_NAME` is preconfigured to ssh successfully as `root`. Refer to `man 5 ssh_config` for more information.

If using the `macOS` keychain is desired for additional security:
* Configure the VM to accept certificate-authenticated SSH
* Generate (`ssh-keygen` on host) and configure (`~/.ssh/authorized_keys` on guest in `root` homedir) an SSH keypair for `root`
* Configure ssh on the host in `~/.ssh/config` to use the private key for the VM host
* Using the `~/.ssh/config` `Host` field, specify the hostname in `config.yaml` as `ssh::hostname`.

Then, `alpine start`, `alpine exec`, `alpine ssh` etc. will use the configured credential(s).