### PR TITLE
Remove `sleep` calls in `Start` and `Launch` processes

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"io/ioutil"
 	"log"
 	"os"
@@ -59,11 +58,8 @@ func delete(cmd *cobra.Command, args []string) {
 
 		err = host.Stop(machineConfig)
 		if err != nil {
-			log.Fatal(errors.New("unable to stop VM: " + err.Error()))
+			log.Println("error stopping vm: " + err.Error())
 		}
-
 		os.RemoveAll(machineConfig.Location)
-
 	}
-
 }

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -168,7 +168,6 @@ func launch(cmd *cobra.Command, args []string) {
 
 	err = host.Launch(machineConfig)
 	if err != nil {
-
 		os.RemoveAll(machineConfig.Location)
 		log.Fatal(err)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -60,5 +60,4 @@ func start(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 }


### PR DESCRIPTION
A number of internals cleanups and changes to remove the need for `Retry` in `Start` and `Launch`. Calls which were previously handled in `Retry` loops now either block until success, or exit with an error. Therefore, either the function succeeds, or does not need to retry as an error must first be resolved. Closes #79.

Overall summary of edits in `qemu/ops.go`:
* in `Stop()`: simplify and add output
* in `getHostArchitecture()`: fix logging format bug
* changes in `Start()` and `Launch()` (below)

in `Start()`:
* use `-daemonize` and `cmd.Run(..)`
* `cmd.Run(...)` blocks until `qemu-system` succeeds and forks to background
* clarify output (`awaiting ssh`, etc)
* Add PID file cleanup on errors
* Remove unneeded `Retry` calls (calls now block or error rather than
  failing silently)
* Mount `mount` directories in `/mnt` per standard Linux practices

in `Launch()`:
* Remove unneeded `Retry` (calls now block or error)
* Document `sfdisk` calls