### PR TITLE
Encrypted publish/Verifiable import via `age`

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -28,10 +28,7 @@ func delete(cmd *cobra.Command, args []string) {
 		log.Fatal("missing VM name")
 	}
 
-	vmList, err := host.ListVMNames()
-	if err != nil {
-		log.Fatal(err)
-	}
+	vmList := host.ListVMNames()
 
 	for _, vmName := range args {
 		exists := utils.StringSliceContains(vmList, vmName)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -53,10 +53,8 @@ func delete(cmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 
-		err = host.Stop(machineConfig)
-		if err != nil {
-			log.Println("error stopping vm: " + err.Error())
-		}
+		host.Stop(machineConfig)
+
 		os.RemoveAll(machineConfig.Location)
 	}
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"io/ioutil"
 	"log"
 	"os"
@@ -59,11 +58,8 @@ func delete(cmd *cobra.Command, args []string) {
 
 		err = host.Stop(machineConfig)
 		if err != nil {
-			log.Fatal(errors.New("unable to stop VM: " + err.Error()))
+			log.Println("error stopping vm: " + err.Error())
 		}
-
 		os.RemoveAll(machineConfig.Location)
-
 	}
-
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -32,10 +32,7 @@ func edit(cmd *cobra.Command, args []string) {
 		log.Fatal("missing VM name")
 	}
 
-	vmList, err := host.ListVMNames()
-	if err != nil {
-		log.Fatal(err)
-	}
+	vmList := host.ListVMNames()
 
 	exists := utils.StringSliceContains(vmList, args[0])
 	if !exists {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -29,10 +29,7 @@ func exec(cmd *cobra.Command, args []string) {
 		log.Fatal("missing VM name")
 	}
 
-	vmList, err := host.ListVMNames()
-	if err != nil {
-		log.Fatal(err)
-	}
+	vmList := host.ListVMNames()
 
 	exists := utils.StringSliceContains(vmList, args[0])
 	if !exists {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -46,6 +46,9 @@ func importMachine(cmd *cobra.Command, args []string) {
 			log.Fatalln("error accessing archive file: " + err.Error())
 		}
 	}
+   if (strings.HasSuffix(archive, ".age") || agePrivate != "") && !utils.CommandExists("age") {
+ 		log.Fatalln("decryption requested but `age` not installed or not in path")
+   }
 
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,9 +4,12 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	osexec "os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	"github.com/beringresearch/macpine/host"
 	qemu "github.com/beringresearch/macpine/qemu"
 	"github.com/beringresearch/macpine/utils"
 	"github.com/spf13/cobra"
@@ -15,76 +18,108 @@ import (
 
 // importCmd iports an Alpine VM from file
 var importCmd = &cobra.Command{
-	Use:   "import NAME",
+	Use:   "import FILE",
 	Short: "Imports an instance.",
 	Run:   importMachine,
+}
 
-	DisableFlagsInUseLine: true,
+var agePrivate string
+
+func init() {
+	includeImportFlags(importCmd)
+}
+
+func includeImportFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&agePrivate, "private-key", "s", "", "Private key file to decrypt the imported archive.")
 }
 
 func importMachine(cmd *cobra.Command, args []string) {
 
-	if len(args) == 0 {
-		log.Fatal("missing VM name")
+	if len(args) == 0 || (len(args) == 1 && args[0] == "") {
+		log.Fatalln("missing archive file name")
+	}
+	archive := args[0]
+	if _, err := os.Stat(archive); err != nil {
+		if os.IsNotExist(err) {
+			log.Fatalln("no archive file found")
+		} else {
+			log.Fatalln("error accessing archive file: " + err.Error())
+		}
 	}
 
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 
-	_, err = utils.CopyFile(args[0], filepath.Join(userHomeDir, ".macpine", args[0]))
+	_, err = utils.CopyFile(archive, filepath.Join(userHomeDir, ".macpine", filepath.Base(archive)))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
+	}
+	archive = filepath.Join(userHomeDir, ".macpine", filepath.Base(archive))
+	defer os.Remove(archive) // delete the copied archive when done
+
+	if strings.HasSuffix(archive, ".age") {
+		decryptName := strings.TrimSuffix(archive, ".age")
+		// archive is encrypted, decrypt with password or private key
+		var ageCmd *osexec.Cmd
+		if agePrivate == "" { // no key specified, assume a password-encrypted archive
+			ageCmd = osexec.Command("age", "-d", "-p", "-o", decryptName, archive)
+		} else {
+			ageCmd = osexec.Command("age", "-d", "-i", agePrivate, "-o", decryptName, archive)
+		}
+		if err := ageCmd.Run(); err != nil {
+			log.Fatalln("failed to decrypt archive: " + err.Error())
+		}
+		defer os.Remove(decryptName) // delete the decrypted archive copy when done
+		archive = decryptName
 	}
 
-	targetDir := filepath.Join(userHomeDir, ".macpine", strings.Split(args[0], ".tar.gz")[0])
-	err = utils.Uncompress(filepath.Join(userHomeDir, ".macpine", args[0]), targetDir)
+	name := strings.TrimSuffix(filepath.Base(archive), ".tar.gz")
+	if utils.StringSliceContains(host.ListVMNames(), name) {
+		var nameExtra int
+		for nameExtra = 1; utils.StringSliceContains(host.ListVMNames(), name+"-"+strconv.Itoa(nameExtra)); nameExtra += 1 {
+			if nameExtra >= 1024 {
+				log.Fatalf("Too many VMs with name prefix %s found. Please rename the archive to retry.\n", name)
+			}
+		}
+		name = name + "-" + strconv.Itoa(nameExtra)
+	}
+	log.Printf("importing %s as %s\n", filepath.Base(archive), name)
+
+	targetDir := filepath.Join(userHomeDir, ".macpine", name)
+	err = utils.Uncompress(archive, targetDir)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln("failed to expand archive: " + err.Error())
 	}
 
 	machineConfig := qemu.MachineConfig{}
 	config, err := ioutil.ReadFile(filepath.Join(targetDir, "config.yaml"))
 	if err != nil {
 		os.RemoveAll(targetDir)
-		log.Fatal(err)
+		log.Fatalln("failed to parse archive: " + err.Error())
 	}
 
 	err = yaml.Unmarshal(config, &machineConfig)
 	if err != nil {
 		os.RemoveAll(targetDir)
-		log.Fatal(err)
+		log.Fatalln("failed to parse archive: " + err.Error())
 	}
 
-	machineConfig.Alias = strings.Split(args[0], ".tar.gz")[0]
+	machineConfig.Alias = name
 	machineConfig.Location = targetDir
 
 	updatedConfig, err := yaml.Marshal(&machineConfig)
 	if err != nil {
 		os.RemoveAll(targetDir)
-		log.Fatal(err)
+		log.Fatalln("failed to update config: " + err.Error())
 	}
 
 	err = ioutil.WriteFile(filepath.Join(targetDir, "config.yaml"), updatedConfig, 0644)
 	if err != nil {
 		os.RemoveAll(targetDir)
-		log.Fatal(err)
+		log.Fatalln("failed to update config: " + err.Error())
 	}
 
-	if err != nil {
-		err = os.Remove(filepath.Join(userHomeDir, ".macpine", args[0]))
-		if err != nil {
-			log.Fatal("unable to import: " + err.Error())
-		}
-
-		os.RemoveAll(targetDir)
-		log.Fatal("unable to import: " + err.Error())
-	}
-
-	err = os.Remove(filepath.Join(userHomeDir, ".macpine", args[0]))
-	if err != nil {
-		os.RemoveAll(targetDir)
-		log.Fatal("unable to import: " + err.Error())
-	}
+	log.Println("successfully imported " + name)
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -46,9 +46,9 @@ func importMachine(cmd *cobra.Command, args []string) {
 			log.Fatalln("error accessing archive file: " + err.Error())
 		}
 	}
-   if (strings.HasSuffix(archive, ".age") || agePrivate != "") && !utils.CommandExists("age") {
- 		log.Fatalln("decryption requested but `age` not installed or not in path")
-   }
+	if (strings.HasSuffix(archive, ".age") || agePrivate != "") && !utils.CommandExists("age") {
+		log.Fatalln("decryption requested but `age` not installed or not in path")
+	}
 
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -135,10 +135,7 @@ func launch(cmd *cobra.Command, args []string) {
 		machineName = utils.GenerateRandomAlias()
 	}
 
-	vmList, err := host.ListVMNames()
-	if err != nil {
-		log.Fatal(err)
-	}
+	vmList := host.ListVMNames()
 
 	exists := utils.StringSliceContains(vmList, machineName)
 	if exists {

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -168,7 +168,6 @@ func launch(cmd *cobra.Command, args []string) {
 
 	err = host.Launch(machineConfig)
 	if err != nil {
-
 		os.RemoveAll(machineConfig.Location)
 		log.Fatal(err)
 	}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -190,7 +190,6 @@ func getAllFlags(cmd *cobra.Command) []string {
 			flags = append(flags, flag[0][1])
 		}
 	}
-
 	return flags
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -35,10 +35,7 @@ func list(cmd *cobra.Command, args []string) {
 	config := []qemu.MachineConfig{}
 	pid := []string{}
 
-	vmNames, err := host.ListVMNames()
-	if err != nil {
-		log.Fatal(err)
-	}
+	vmNames := host.ListVMNames()
 
 	for _, f := range vmNames {
 

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -21,7 +21,7 @@ var publishCmd = &cobra.Command{
 	Short: "Publish an instance.",
 	Run:   publish,
 
-	ValidArgsFunction:     flagsPublish,
+	ValidArgsFunction: flagsPublish,
 }
 
 var ageRecipient, ageIdent string
@@ -49,10 +49,7 @@ func publish(cmd *cobra.Command, args []string) {
 		log.Fatalln("missing VM name")
 	}
 
-	vmList, err := host.ListVMNames()
-	if err != nil {
-		log.Fatalln(err)
-	}
+	vmList := host.ListVMNames()
 
 	exists := utils.StringSliceContains(vmList, args[0])
 	if !exists {

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -34,10 +34,7 @@ func shell(cmd *cobra.Command, args []string) {
 		log.Fatal("missing VM name")
 	}
 
-	vmList, err := host.ListVMNames()
-	if err != nil {
-		log.Fatal(err)
-	}
+	vmList := host.ListVMNames()
 
 	exists := utils.StringSliceContains(vmList, args[0])
 	if !exists {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -60,5 +60,4 @@ func start(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -34,10 +34,7 @@ func start(cmd *cobra.Command, args []string) {
 		log.Fatal("missing VM name")
 	}
 
-	vmList, err := host.ListVMNames()
-	if err != nil {
-		log.Fatal(err)
-	}
+	vmList := host.ListVMNames()
 
 	exists := utils.StringSliceContains(vmList, args[0])
 	if !exists {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -32,10 +32,7 @@ func stop(cmd *cobra.Command, args []string) {
 		log.Fatal("missing VM name")
 	}
 
-	vmList, err := host.ListVMNames()
-	if err != nil {
-		log.Fatal(err)
-	}
+	vmList := host.ListVMNames()
 
 	exists := utils.StringSliceContains(vmList, args[0])
 	if !exists {

--- a/docs/docs/publish_instance.md
+++ b/docs/docs/publish_instance.md
@@ -1,0 +1,90 @@
+# Publishing and Importing Instances
+
+In order to back up or share instances (including `macpine` configurations and the VM filesystem), `alpine publish` and
+`alpine import` are provided.
+
+## Basic Usage
+
+```sh
+$ alpine list
+NAME       OS         STATUS      SSH    PORTS ARCH        PID
+example    alpine     Stopped     22           aarch64     -
+$ alpine publish example
+...
+```
+
+`publish` will then create `example.tar.gz`, a compressed archive of the relevant `macpine` and VM files. Note that `publish`
+will stop a running instance before creating an archive.
+
+```sh
+$ alpine import example.tar.gz
+```
+
+`import` will then create a VM `example` (or `example-1`, `example-2`, ... if the name is taken).
+
+## Publishing with Authenticated Encryption
+
+`macpine` supports using [`age`](https://github.com/FiloSottile/age), a modern file encryption tool, to add authenticated encryption
+to archives. `age` supports encryption with passphrases, but also with SSH keys (symmetrically with private keys, or asymmetrically
+with public keys) and its own `age-keygen` custom format [`Curve25519`](https://en.wikipedia.org/wiki/Curve25519) keys.
+
+`age` can be installed with: `go install filippo.io/age/cmd/...@latest`, or with many common package managers including:
+* macOS `brew` `port`
+* *nix `apk` `pacman` `apt` `dnf` `emerge` `nix-env` `zypper` `xbps-install` `pkg` `pkg_add`
+* Windows `choco` `scoop`
+
+`alpine publish -h`:
+```sh
+Publish an instance.
+
+Usage:
+  alpine publish NAME
+
+Flags:
+  -h, --help                 help for publish
+  -p, --password             Encrypt published VM with interactive passphrase prompt (symmetric).
+  -s, --private-key string   Encrypt published VM with ssh/age secret key (symmetric).
+  -k, --public-key string    Encrypt published VM with ssh/age public key (asymmetric).
+```
+
+`-p` encrypts the archive `example.tar.gz.age` with a key derived from a securely-generated (default) or user-provided passphrase.
+This option will prompt the user interactively for a passphrase input, and with no input (just `[Return]`) will generate and display
+a secure passphrase. This is symmetric encryption: the same passphrase is used to encrypt and decrypt (when using `import`).
+
+`-s` encrypts the archive *symmetrically* with a key derived from the provided *secret* key file. The same key file must be provided
+for decryption during `import`.
+
+`-k` encrypts the archive *asymmetrically* with a key derived from the provided *public* key file. The corresponding *secret* key
+(a.k.a. private key) must be provided for decryption.
+
+## Importing an Encrypted Archive
+
+`age` uses authenticated encryption, therefore any modification to the data of a VM archive will cause decryption (and therefore `import`)
+to fail with an error. Note that if the password/secret key is lost and the original unencrypted archive deleted, data may be
+irretrievably lost.
+
+If `age` is used with a password (`-p`/`--password` during `publish`), `age` will store this information in the archive. Therefore,
+no command flag is needed -- `age` will detect and interactively prompt for the passphrase. If a public (`-k`) or private (`-s`)
+key is used to encrypt, the (corresponding or same, respectively) private key must be supplied with the `-s` flag during `import`.
+
+```sh
+$ ssh-keygen -t ed25519
+...
+$ alpine list
+NAME       OS         STATUS      SSH    PORTS ARCH        PID
+example    alpine     Stopped     22           aarch64     -
+$ alpine export -k ~/.ssh/id_ed25519.pub example # encrypt using public key
+$ alpine delete example
+$ alpine list
+NAME       OS         STATUS      SSH    PORTS ARCH        PID
+$ alpine import -s ~/.ssh/id_ed25519 example     # decrypt using private key
+$ alpine list
+NAME       OS         STATUS      SSH    PORTS ARCH        PID
+example    alpine     Stopped     22           aarch64     -
+```
+
+Encrypting a VM archive to an SSH key of a GitHub user `username`:
+```sh
+$ curl https://github.com/username.keys -o username_key
+$ alpine publish -k username_key example-vm
+```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/beringresearch/macpine
 go 1.18
 
 require (
-	github.com/spf13/cobra v1.4.0
+	github.com/spf13/cobra v1.5.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
+github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=

--- a/host/stop.go
+++ b/host/stop.go
@@ -6,10 +6,5 @@ import (
 
 // Stop launches a new VM using user-defined configuration
 func Stop(config qemu.MachineConfig) error {
-	err := config.Stop()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return config.Stop()
 }

--- a/host/utils.go
+++ b/host/utils.go
@@ -2,24 +2,23 @@ package host
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
 
-func ListVMNames() ([]string, error) {
+func ListVMNames() []string {
 	var vmList []string
 
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		return vmList, nil
+		return vmList
 	}
 
 	dirList, err := ioutil.ReadDir(filepath.Join(userHomeDir, ".macpine"))
 	if err != nil {
-		return vmList, nil
+		return vmList
 	}
 
 	for _, f := range dirList {
@@ -29,15 +28,10 @@ func ListVMNames() ([]string, error) {
 
 	}
 
-	return vmList, nil
+	return vmList
 }
 
 // autocomplete with VM Names
 func AutoCompleteVMNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	listVMNames, err := ListVMNames()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return listVMNames, cobra.ShellCompDirectiveNoFileComp
+	return ListVMNames(), cobra.ShellCompDirectiveNoFileComp
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -124,9 +124,9 @@ func Ping(ip string, port string) error {
 }
 
 // StringSliceContains check if string value is in []string
-func StringSliceContains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
+func StringSliceContains(haystack []string, needle string) bool {
+	for _, x := range haystack {
+		if x == needle {
 			return true
 		}
 	}


### PR DESCRIPTION
Closes #92.

Features:
* Add `age` functionality in `cmd/publish.go`
  * Add three age encryption options
  * Add command flags
  * Update shell completion tooling for new flags
* Add age functionality to `cmd/import.go`
  * Support passphrase and private key decryption
  * Add `defer`'d cleanup calls to delete temporary archive copies
  * Add cli arg for private key
  * Passphrase decrypt handled by `age`, no need for flag
  * Add error handling and more informative logging
  * Automatically increment VM name if name is taken

Deps:
* Bump cobra to 1.5.0 for mutex flag groups

Cleanups:
* Simplify `host/stop.go`
* `ListVMNames()` never returns a non-nil error, simplify its use in various `cmd/*.go`
* Ignore error stopping VM in `cmd/delete.go`

Docs:
* Add `publish_instance.md` documentation