### PR TITLE
Fix issue in `cmd/start.go`

### DIFF
--- a/host/start.go
+++ b/host/start.go
@@ -1,7 +1,7 @@
 package host
 
 import (
-	"errors"
+	"log"
 	"strconv"
 	"strings"
 
@@ -14,7 +14,8 @@ func Start(config qemu.MachineConfig) error {
 
 	status, _ := config.Status()
 	if status == "Running" {
-		return errors.New(config.Alias + " is already running")
+		log.Println(config.Alias + " is already running")
+		return nil
 	}
 
 	ports, err := utils.ParsePort(config.Port)


### PR DESCRIPTION
If `alpine start` is called on a running VM, `host/start.go` will return an error that the VM is already running -- which `cmd/start.go` interprets as a failure to start the VM, thus annoyingly calling `stop`.

This fixes that.