### PR TITLE
Add restart command

### DIFF
--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/beringresearch/macpine/host"
+	qemu "github.com/beringresearch/macpine/qemu"
+	"github.com/beringresearch/macpine/utils"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// stopCmd stops an Alpine instance
+var restartCmd = &cobra.Command{
+	Use:   "restart <instance> [<instance>...]",
+	Short: "Stop and start an instance.",
+	Run:   restart,
+
+	ValidArgsFunction:     host.AutoCompleteVMNames,
+	DisableFlagsInUseLine: true,
+}
+
+func restart(cmd *cobra.Command, args []string) {
+	userHomeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(args) == 0 {
+		log.Fatal("missing VM name")
+	}
+
+	vmList := host.ListVMNames()
+	wasErr := false
+	for i, vmName := range args {
+		if utils.StringSliceContains(args[:i], vmName) {
+			continue
+		}
+		exists := utils.StringSliceContains(vmList, vmName)
+		if !exists {
+			wasErr = true
+			log.Println(errors.New("unknown machine " + vmName))
+			continue
+		}
+
+		machineConfig := qemu.MachineConfig{}
+		config, err := ioutil.ReadFile(filepath.Join(userHomeDir, ".macpine", vmName, "config.yaml"))
+		if err != nil {
+			wasErr = true
+			log.Println(err)
+			continue
+		}
+		err = yaml.Unmarshal(config, &machineConfig)
+		if err != nil {
+			wasErr = true
+			log.Println(err)
+			continue
+		}
+
+		log.Println("restarting " + vmName + "...")
+		err = host.Stop(machineConfig)
+		if err != nil {
+			wasErr = true
+			log.Println(err)
+			continue
+		}
+
+		time.Sleep(time.Second)
+
+		err = host.Start(machineConfig)
+		if err != nil {
+			host.Stop(machineConfig)
+			wasErr = true
+			log.Println(err)
+			continue
+		}
+	}
+	if wasErr {
+		log.Fatalln("error restarting VM(s)")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ func init() {
 	MacpineCmd.AddCommand(launchCmd)
 	MacpineCmd.AddCommand(stopCmd)
 	MacpineCmd.AddCommand(startCmd)
+	MacpineCmd.AddCommand(restartCmd)
 	MacpineCmd.AddCommand(deleteCmd)
 	MacpineCmd.AddCommand(listCmd)
 	MacpineCmd.AddCommand(publishCmd)

--- a/host/start.go
+++ b/host/start.go
@@ -38,10 +38,5 @@ func Start(config qemu.MachineConfig) error {
 		}
 	}
 
-	err = config.Start()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return config.Start()
 }


### PR DESCRIPTION
* add `cmd/restart.go`
  * accepts multiple instances
  * reports errors immediately rather than deferred because output is long during startup
* small simplification in `host/start.go`
* add restart to `cmd/root.go`

Closes #94