### PR TITLE
Remove OS column from `alpine list`

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -12,7 +12,7 @@ import (
 // infoCmd displays macpine machine info
 var infoCmd = &cobra.Command{
 	Use:   "info NAME",
-	Short: "Display information about instances.",
+	Short: "Display information about an instance.",
 	Run:   macpineInfo,
 
 	ValidArgsFunction:     host.AutoCompleteVMNames,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -61,12 +61,11 @@ func list(cmd *cobra.Command, args []string) {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-	fmt.Fprintln(w, "NAME\tOS\tSTATUS\tSSH\tPORTS\tARCH\tPID\tTAGS\t")
+	fmt.Fprintln(w, "NAME\tSTATUS\tSSH\tPORTS\tARCH\tPID\tTAGS\t")
 	for i, machine := range config {
 		spacer := "    \t"
 		row := []string{
 			machine.Alias,
-			strings.Split(machine.Image, "_")[0],
 			status[i],
 			machine.SSHPort,
 			machine.Port,

--- a/host/info.go
+++ b/host/info.go
@@ -29,8 +29,9 @@ func Info(vmName string) (string, error) {
 		log.Fatal(err)
 	}
 
-	info := fmt.Sprintf("Name: %s\nArch: %s\nDisk usage: %s\nMemory usage: %s\nCPU usage: %s\nMounts: %s\nTags: %s\n",
+	info := fmt.Sprintf("Name: %s\nImage: %s\nArch: %s\nDisk usage: %s\nMemory usage: %s\nCPU usage: %s\nMounts: %s\nTags: %s\n",
 		machineConfig.Alias,
+		machineConfig.Image,
 		machineConfig.Arch,
 		machineConfig.Disk,
 		machineConfig.Memory,


### PR DESCRIPTION
* Change in `cmd/list.go`
* Add `Image` to `alpine info` in case this is needed
* Minor correction in `cmd/info.go` documentation (single instance)

Closes #110 