### PR TITLE
Make cache directory hidden in ~/.macpine to avoid confusion with VMs

### DIFF
--- a/host/utils.go
+++ b/host/utils.go
@@ -22,7 +22,7 @@ func ListVMNames() []string {
 	}
 
 	for _, f := range dirList {
-		if f.Name() != "cache" {
+		if f.Name() != ".cache" {
 			vmList = append(vmList, f.Name())
 		}
 	}

--- a/qemu/ops.go
+++ b/qemu/ops.go
@@ -400,7 +400,7 @@ func (c *MachineConfig) Launch() error {
 		return err
 	}
 
-	cacheDir := filepath.Join(userHomeDir, ".macpine", "cache")
+	cacheDir := filepath.Join(userHomeDir, ".macpine", ".cache")
 	err = os.MkdirAll(cacheDir, os.ModePerm)
 	if err != nil {
 		return err


### PR DESCRIPTION
NOTE: if this is accepted, we should add something to the install scripts ideally as a one-time operation which checks for `~/.macpine/cache` and moves it to `~/.macpine/.cache` to avoid breakage.

Alternatively this could be an unnecessary hassle and if so just close this out. I'm unfamiliar with the how the brew/macports side of things is done so if that's not easy, let's just leave it as-is.