### PR TITLE
Tagging vms for efficient multi-instance commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sudo chmod +x alpine
 sudo mv alpine /usr/local/bin/
 ```
 
-## Install from Homebrew
+## Install from Homebrew (recommended)
 
 ```bash
 brew install macpine
@@ -67,37 +67,37 @@ make #compiles the project into a local bin/ directory
 make install #installs binaries to /usr/local (or other configured PREFIX)
 ```
 
-
 # Getting Started
 
-To launch a brand new VM:
+To launch a new instance:
 
 ```bash
 alpine launch #launches with default parameters
 alpine launch -a aarch64 #create an aarch64 instance
-alpine launch -d 10G -c 4 -m 2048 #create a machine with a 10GB disk, 4 cpus and 2GB of RAM
-
+alpine launch -d 10G -c 4 -m 2048 #create an instance with a 10GB disk, 4 cpus and 2GB of RAM
 ```
 
-Access VM via ssh:
+`alpine help launch` to view defaults and other launch options.
+
+Access instance via ssh:
 
 ```bash
-alpine launch -s 22 #launch a VM and expose SSH port to host port 22
-ssh root@localhost -p 22 #password: root
-alpine ssh $VMNAME #attach to the VM shell
+alpine launch -s 22 #launch an instance and expose SSH port to host port 22
+alpine ssh <instance name> #attach shell to instance
+#Or: ssh root@localhost -p 22 #password: root
 ```
 
-Expose additional VM ports to host:
+Expose additional instance ports to host:
 
 ```bash
 alpine launch -s 23 -p 8888,5432 #launch a VM, expose SSH to host port 23 and forward host ports 8888 and 5432 to VM ports 8888 and 5432
 alpine launch -s 8023 -p 8081:8082,8083 #launch a VM, expose SSH to host port 8023, forward host port 8081 to VM port 8082, and forward
                                         #host port 8083 to VM port 8083
-alpine launch -s 9023 -p 9091u,9092:9093u #launch a VM, expose SSH to host port 9023, forward (UDP) host port 9091 to VM port 9091, and forward (UDP)
-                                        #host port 9092 to VM port 9093
+alpine launch -s 9023 -p 9091u,9092:9093u #launch a VM, expose SSH to host port 9023, forward (UDP) host port 9091 to VM port 9091,
+                                          #and forward (UDP) host port 9092 to VM port 9093
 ```
 
-VMs can be easily packaged for export and re-use as tar.gz files:
+Instances can be easily packaged for backup or sharing as tar.gz files:
 
 ```bash
 alpine list
@@ -151,7 +151,9 @@ Flags:
 Use "alpine [command] --help" for more information about a command.
 ```
 
-**Multiple VMs per command:** some commands (`delete`, `edit`, `publish`, `restart`, `start`, `stop`) accept multiple instance names and will repeat the operation over each unique named instance once.
+**Multiple instances in a command:** some commands (`delete`, `edit`, `publish`, `restart`, `start`, `stop`) accept multiple instance names and will repeat the operation over each unique named instance once.
+
+**Tags:** using `alpine tag`, instances can be tagged; tags can be used in multi-instance commands (see above) e.g. `alpine start +daemon` will start all instances which have had been tagged `daemon` with `alpine tag <instance name> daemon`.
 
 **Shell autocompletion:** shell command completion files (installed by default with `brew install macpine`) can be generated with `alpine completion [bash|zsh|fish|powershell]`.
 See `alpine completion -h` or the [completion documentation](docs/docs/completions.md) for more information.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Flags:
 Use "alpine [command] --help" for more information about a command.
 ```
 
-**Multiple VMs per command:** some commands accept multiple instance names and will repeat the operation over each unique named instance once.
+**Multiple VMs per command:** some commands (`delete`, `edit`, `publish`, `restart`, `start`, `stop`) accept multiple instance names and will repeat the operation over each unique named instance once.
 
 **Shell autocompletion:** shell command completion files (installed by default with `brew install macpine`) can be generated with `alpine completion [bash|zsh|fish|powershell]`.
 See `alpine completion -h` or the [completion documentation](docs/docs/completions.md) for more information.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -16,7 +16,7 @@ import (
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete <instance> [<instance>...]",
-	Short: "Delete named instances.",
+	Short: "Delete instances.",
 	Run:   delete,
 
 	ValidArgsFunction:     host.AutoCompleteVMNames,
@@ -26,7 +26,7 @@ var deleteCmd = &cobra.Command{
 func delete(cmd *cobra.Command, args []string) {
 
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	vmList := host.ListVMNames()
@@ -37,7 +37,7 @@ func delete(cmd *cobra.Command, args []string) {
 		}
 		exists := utils.StringSliceContains(vmList, vmName)
 		if !exists {
-			errs[i] = utils.CmdResult{Name: vmName, Err: errors.New("unknown machine " + vmName)}
+			errs[i] = utils.CmdResult{Name: vmName, Err: errors.New("unknown instance " + vmName)}
 			continue
 		}
 
@@ -77,6 +77,6 @@ func delete(cmd *cobra.Command, args []string) {
 		}
 	}
 	if wasErr {
-		log.Fatalln("error deleting VM(s)")
+		log.Fatalln("error deleting instance(s)")
 	}
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -19,7 +19,7 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete instances.",
 	Run:   delete,
 
-	ValidArgsFunction:     host.AutoCompleteVMNames,
+	ValidArgsFunction:     host.AutoCompleteVMNamesOrTags,
 	DisableFlagsInUseLine: true,
 }
 
@@ -27,6 +27,11 @@ func delete(cmd *cobra.Command, args []string) {
 
 	if len(args) == 0 {
 		log.Fatal("missing instance name")
+	}
+
+	args, err := host.ExpandTagArguments(args)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	vmList := host.ListVMNames()

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -29,7 +29,7 @@ func edit(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	vmList := host.ListVMNames()
@@ -39,7 +39,7 @@ func edit(cmd *cobra.Command, args []string) {
 		}
 		exists := utils.StringSliceContains(vmList, vmName)
 		if !exists {
-			log.Fatalln("unknown machine " + vmName)
+			log.Fatalln("unknown instance " + vmName)
 		}
 	}
 
@@ -81,6 +81,6 @@ func edit(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("error while editing: %v\n", err)
 	} else {
-		log.Println("configuration(s) saved, restart VM(s) for changes to take effect")
+		log.Println("configuration(s) saved, restart instance(s) for changes to take effect")
 	}
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -17,7 +17,7 @@ var editCmd = &cobra.Command{
 	Short: "Edit instance configuration.",
 	Run:   edit,
 
-	ValidArgsFunction:     host.AutoCompleteVMNames,
+	ValidArgsFunction:     host.AutoCompleteVMNamesOrTags,
 	DisableFlagsInUseLine: true,
 }
 
@@ -30,6 +30,11 @@ func edit(cmd *cobra.Command, args []string) {
 
 	if len(args) == 0 {
 		log.Fatal("missing instance name")
+	}
+
+	args, err = host.ExpandTagArguments(args)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	vmList := host.ListVMNames()

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -16,8 +16,8 @@ import (
 
 // execCmd executes command on alpine vm
 var execCmd = &cobra.Command{
-	Use:   "exec NAME COMMAND",
-	Short: "execute COMMAND over ssh.",
+	Use:   "exec <instance> <command>",
+	Short: "execute a command on an instance over ssh.",
 	Run:   exec,
 
 	ValidArgsFunction:     host.AutoCompleteVMNames,
@@ -26,13 +26,13 @@ var execCmd = &cobra.Command{
 
 func exec(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	vmList := host.ListVMNames()
 	exists := utils.StringSliceContains(vmList, args[0])
 	if !exists {
-		log.Fatal("unknown machine " + args[0])
+		log.Fatal("unknown instance " + args[0])
 	}
 
 	instName := args[0]

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -15,8 +15,8 @@ import (
 
 // importCmd iports an Alpine VM from file
 var importCmd = &cobra.Command{
-	Use:   "import NAME",
-	Short: "Imports an instance.",
+	Use:   "import <archive>",
+	Short: "Imports an instance archived with `alpine publish`.",
 	Run:   importMachine,
 
 	DisableFlagsInUseLine: true,
@@ -25,7 +25,7 @@ var importCmd = &cobra.Command{
 func importMachine(cmd *cobra.Command, args []string) {
 
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	userHomeDir, err := os.UserHomeDir()

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -11,7 +11,7 @@ import (
 
 // infoCmd displays macpine machine info
 var infoCmd = &cobra.Command{
-	Use:   "info NAME",
+	Use:   "info <instance>",
 	Short: "Display information about an instance.",
 	Run:   macpineInfo,
 
@@ -21,7 +21,7 @@ var infoCmd = &cobra.Command{
 
 func macpineInfo(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	for _, vmName := range args {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,7 +18,7 @@ import (
 // listCmd lists Alpine instances
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List all available instances.",
+	Short: "List instances.",
 	Run:   list,
 
 	DisableFlagsInUseLine: true,

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -21,7 +21,7 @@ var publishCmd = &cobra.Command{
 	Short: "Publish an instance.",
 	Run:   publish,
 
-	ValidArgsFunction:     host.AutoCompleteVMNames,
+	ValidArgsFunction:     host.AutoCompleteVMNamesOrTags,
 	DisableFlagsInUseLine: true,
 }
 
@@ -34,6 +34,11 @@ func publish(cmd *cobra.Command, args []string) {
 
 	if len(args) == 0 {
 		log.Fatal("missing instance name")
+	}
+
+	args, err = host.ExpandTagArguments(args)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	vmList := host.ListVMNames()

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -33,7 +33,7 @@ func publish(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	vmList := host.ListVMNames()
@@ -44,7 +44,7 @@ func publish(cmd *cobra.Command, args []string) {
 		}
 		exists := utils.StringSliceContains(vmList, vmName)
 		if !exists {
-			errs[i] = utils.CmdResult{Name: vmName, Err: errors.New("unknown machine " + vmName)}
+			errs[i] = utils.CmdResult{Name: vmName, Err: errors.New("unknown instance " + vmName)}
 			continue
 		}
 
@@ -103,6 +103,6 @@ func publish(cmd *cobra.Command, args []string) {
 		}
 	}
 	if wasErr {
-		log.Fatalln("error publishing VM(s)")
+		log.Fatalln("error publishing instance(s)")
 	}
 }

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -32,7 +32,7 @@ func rename(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) < 1 {
-		log.Fatalln("missing VM name")
+		log.Fatalln("missing instance name")
 	}
 	if len(args) < 2 {
 		log.Fatalln("missing new name argument")
@@ -42,7 +42,7 @@ func rename(cmd *cobra.Command, args []string) {
 	vmList := host.ListVMNames()
 	exists := utils.StringSliceContains(vmList, vmName)
 	if !exists {
-		log.Fatalln("unknown machine " + vmName)
+		log.Fatalln("unknown instance " + vmName)
 	}
 
 	newName := args[1]
@@ -51,7 +51,7 @@ func rename(cmd *cobra.Command, args []string) {
 	configDir := filepath.Join(userHomeDir, ".macpine")
 	files, err := os.ReadDir(configDir)
 	if err != nil {
-		log.Fatalf("error reading macpine config directory: %v\n", err)
+		log.Fatalf("error reading config directory: %v\n", err)
 	}
 
 	for _, oldVM := range files {

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -32,7 +32,7 @@ func restart(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	vmList := host.ListVMNames()
@@ -44,7 +44,7 @@ func restart(cmd *cobra.Command, args []string) {
 		exists := utils.StringSliceContains(vmList, vmName)
 		if !exists {
 			wasErr = true
-			log.Println(errors.New("unknown machine " + vmName))
+			log.Println(errors.New("unknown instance " + vmName))
 			continue
 		}
 
@@ -81,6 +81,6 @@ func restart(cmd *cobra.Command, args []string) {
 		}
 	}
 	if wasErr {
-		log.Fatalln("error restarting VM(s)")
+		log.Fatalln("error restarting instance(s)")
 	}
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -21,7 +21,7 @@ var restartCmd = &cobra.Command{
 	Short: "Stop and start an instance.",
 	Run:   restart,
 
-	ValidArgsFunction:     host.AutoCompleteVMNames,
+	ValidArgsFunction:     host.AutoCompleteVMNamesOrTags,
 	DisableFlagsInUseLine: true,
 }
 
@@ -33,6 +33,11 @@ func restart(cmd *cobra.Command, args []string) {
 
 	if len(args) == 0 {
 		log.Fatal("missing instance name")
+	}
+
+	args, err = host.ExpandTagArguments(args)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	vmList := host.ListVMNames()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ var completionOptions = cobra.CompletionOptions{DisableDefaultCmd: true}
 // MacpineCmd represents the base command when called without any subcommands
 var MacpineCmd = &cobra.Command{
 	Use:               "alpine",
-	Short:             "Create, control and connect to Alpine instances.",
+	Short:             "Create, control, and connect to Alpine instances.",
 	Long:              ``,
 	CompletionOptions: completionOptions,
 }

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -15,8 +15,8 @@ import (
 
 // shellCmd starts an Alpine instance
 var shellCmd = &cobra.Command{
-	Use:   "ssh NAME",
-	Short: "Attach an interactive shell to an instance.",
+	Use:   "ssh <instance>",
+	Short: "Attach an interactive shell to an instance via ssh.",
 	Run:   shell,
 
 	ValidArgsFunction:     host.AutoCompleteVMNames,
@@ -31,13 +31,13 @@ func shell(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	vmList := host.ListVMNames()
 	exists := utils.StringSliceContains(vmList, args[0])
 	if !exists {
-		log.Fatal("unknown machine " + args[0])
+		log.Fatal("unknown instance " + args[0])
 	}
 
 	machineConfig := qemu.MachineConfig{}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -20,7 +20,7 @@ var startCmd = &cobra.Command{
 	Short: "Start an instance.",
 	Run:   start,
 
-	ValidArgsFunction:     host.AutoCompleteVMNames,
+	ValidArgsFunction:     host.AutoCompleteVMNamesOrTags,
 	DisableFlagsInUseLine: true,
 }
 
@@ -33,6 +33,11 @@ func start(cmd *cobra.Command, args []string) {
 
 	if len(args) == 0 {
 		log.Fatal("missing instance name")
+	}
+
+	args, err = host.ExpandTagArguments(args)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	vmList := host.ListVMNames()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -32,7 +32,7 @@ func start(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	vmList := host.ListVMNames()
@@ -43,7 +43,7 @@ func start(cmd *cobra.Command, args []string) {
 		}
 		exists := utils.StringSliceContains(vmList, vmName)
 		if !exists {
-			errs[i] = utils.CmdResult{Name: vmName, Err: errors.New("unknown machine " + vmName)}
+			errs[i] = utils.CmdResult{Name: vmName, Err: errors.New("unknown instance " + vmName)}
 			continue
 		}
 
@@ -76,6 +76,6 @@ func start(cmd *cobra.Command, args []string) {
 		}
 	}
 	if wasErr {
-		log.Fatalln("error starting VM(s)")
+		log.Fatalln("error starting instance(s)")
 	}
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -18,7 +18,7 @@ var stopCmd = &cobra.Command{
 	Short: "Stop an instance.",
 	Run:   stop,
 
-	ValidArgsFunction:     host.AutoCompleteVMNames,
+	ValidArgsFunction:     host.AutoCompleteVMNamesOrTags,
 	DisableFlagsInUseLine: true,
 }
 
@@ -31,6 +31,11 @@ func stop(cmd *cobra.Command, args []string) {
 
 	if len(args) == 0 {
 		log.Fatal("missing instance name")
+	}
+
+	args, err = host.ExpandTagArguments(args)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	vmList := host.ListVMNames()

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -30,7 +30,7 @@ func stop(cmd *cobra.Command, args []string) {
 	}
 
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 
 	vmList := host.ListVMNames()
@@ -41,7 +41,7 @@ func stop(cmd *cobra.Command, args []string) {
 		}
 		exists := utils.StringSliceContains(vmList, vmName)
 		if !exists {
-			errs[i] = utils.CmdResult{Name: vmName, Err: errors.New("unknown machine " + vmName)}
+			errs[i] = utils.CmdResult{Name: vmName, Err: errors.New("unknown instance " + vmName)}
 			continue
 		}
 
@@ -64,6 +64,6 @@ func stop(cmd *cobra.Command, args []string) {
 		}
 	}
 	if wasErr {
-		log.Fatalln("error stopping VM(s)")
+		log.Fatalln("error stopping instance(s)")
 	}
 }

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -26,7 +26,7 @@ func includeTagFlag(cmd *cobra.Command) {
 
 // infoCmd displays macpine machine info
 var tagCmd = &cobra.Command{
-	Use:   "tag NAME tag1 [tag2...]",
+	Use:   "tag [-r] <instance> <tag1> [<tag2>...]",
 	Short: "Add or remove tags from an instance.",
 	Run:   macpineTag,
 
@@ -44,7 +44,7 @@ func validateTags(tags []string) {
 
 func macpineTag(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		log.Fatal("missing VM name")
+		log.Fatal("missing instance name")
 	}
 	vmName := args[0]
 
@@ -85,7 +85,7 @@ func macpineTag(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("(%s) active tags: "+strings.Join(machineConfig.Tags[:], ", "), machineConfig.Alias)
+	log.Printf("%s tags: "+strings.Join(machineConfig.Tags[:], ", "), machineConfig.Alias)
 }
 
 func find(s []string, t string) (int, bool) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -263,7 +263,7 @@ func (wc *WriteCounter) Write(p []byte) (int, error) {
 
 func (wc WriteCounter) PrintProgress() {
 	fmt.Printf("\r%s", strings.Repeat(" ", 35))
-	fmt.Printf("\rRetrieving image... %3dMB complete", wc.Total/1000000)
+	fmt.Printf("\rretrieving image... %3dMB complete", wc.Total/1000000)
 }
 
 func DownloadFile(filepath string, url string) error {


### PR DESCRIPTION
Tags will now be expanded for commands with multiple instance support:
* `cmd/delete.go`
* `cmd/edit.go`
* `cmd/publish.go`
* `cmd/restart.go`
* `cmd/start.go`
* `cmd/stop.go`

Format is: `alpine start +tagname`

For example:
```bash
$ alpine list
NAME       STATUS      SSH    PORTS     ARCH        PID   TAGS
mysql      Stopped     2022   3306      aarch64     -     daemon
foobar     Stopped     2023             aarch64     -     daemon,dev

$ alpine start +daemon
... starts mysql and foobar ...

$ alpine stop mysql +dev
... stops mysql and foobar ...
```