### PR TITLE
auotstart an instance on publish if it was already running

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -78,7 +78,9 @@ func publish(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		err = host.Stop(machineConfig)
+		vmStatus, _ := host.Status(machineConfig)
+
+		err = host.Pause(machineConfig)
 		if err != nil {
 			errs[i] = utils.CmdResult{Name: vmName, Err: err}
 			continue
@@ -109,6 +111,12 @@ func publish(cmd *cobra.Command, args []string) {
 			ext = ".age"
 		}
 		log.Printf("creating archive %s...\n", machineConfig.Alias+".tar.gz"+ext)
+
+		files = utils.StringSliceDifference(files,
+			[]string{filepath.Join(machineConfig.Location, "alpine.qmp"),
+				filepath.Join(machineConfig.Location, "alpine.sock"),
+				filepath.Join(machineConfig.Location, "alpine.pid")})
+
 		err = utils.Compress(files, out)
 		if err != nil {
 			errs[i] = utils.CmdResult{Name: vmName, Err: err}
@@ -117,6 +125,14 @@ func publish(cmd *cobra.Command, args []string) {
 
 		if encrypt {
 			err = encryptArchive(&machineConfig)
+			if err != nil {
+				errs[i] = utils.CmdResult{Name: vmName, Err: err}
+				continue
+			}
+		}
+
+		if vmStatus == "Running" {
+			err = host.Resume(machineConfig)
 			if err != nil {
 				errs[i] = utils.CmdResult{Name: vmName, Err: err}
 				continue

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -80,7 +80,9 @@ func publish(cmd *cobra.Command, args []string) {
 
 		vmStatus, _ := host.Status(machineConfig)
 
+		machineConfig.Exec("sync && sleep 1", true)
 		err = host.Pause(machineConfig)
+
 		if err != nil {
 			errs[i] = utils.CmdResult{Name: vmName, Err: err}
 			continue

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -23,6 +23,22 @@ import (
 //go:embed *.txt
 var f embed.FS
 
+// StringSliceDifference creates a set differences between slices a and b
+// difference returns the elements in `a` that aren't in `b`.
+func StringSliceDifference(a, b []string) []string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[x] = struct{}{}
+	}
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
+}
+
 // SupportsHugePages
 func SupportsHugePages() (bool, error) {
 	sc, err := syscall.Sysctl("machdep.cpu.extfeatures")


### PR DESCRIPTION
This addresses #136 

The pull request also makes a switch to pause/resume rather than stop/start as that is considerably faster.

The VM is auto started only if it had been running prior to publish.

It is desirable for the VM to be stopped for publish,, but is not essential. A stopped VM will contain a fixed state (if there were any write operations running). For safety, it may be desirable, to prevent the user from publishing a Running VM and force the user to manually stop/pause it to ensure the user remains in control of the final publishable VM step.

Can have a discussion about this and incorporate into this PR if desirable.