### PR TITLE
Avx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sudo mv alpine /usr/local/bin/
 #export PATH="$PATH:/usr/local/bin"
 ```
 
-Macpine depends on QEMU >= 6.2.0_1:
+Macpine depends on QEMU >= 7.22.0:
 
 ```bash
 brew install qemu

--- a/qemu/ops.go
+++ b/qemu/ops.go
@@ -358,7 +358,7 @@ func (c *MachineConfig) Start() error {
 
 	cpuType := map[string]string{
 		"aarch64":      "cortex-a72",
-		"x86_64":       "qemu64",
+		"x86_64":       "qemu64,+avx,+avx2",
 		"x86_64_host":  "host" + hugePages,
 		"aarch64_host": "host"}
 


### PR DESCRIPTION
This adds AVX/AVX2 instruction support to x86 emulation. This feature should be able to enable installation of tools such as tensorflow inside containers running on top of macpine VMs