### PR TITLE
Update troubleshooting.md

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -52,3 +52,7 @@ More information on `chronyd` can be found on [the Arch wiki](https://wiki.archl
     machines which can reach the host can send traffic to the guest. If this is not desired, enable a host firewall. You do not need to
     click "Allow" for incoming connection to `qemu` when prompted by macOS as loopback connections (i.e. directly from the host itself)
     will still be allowed.
+
+### Other issues
+
+* If apline is not able to resize the disk it will error out with this message. eg: `unable to resize disk: signal: abort trap`. Internally it runs this command `qemu-img resize <IMAGE_LOCATION> <+SIZE>`. if qemu-img resize command errors out with `dyld[28316]: Library not loaded: /opt/homebrew/opt/libunistring/lib/libunistring.2.dylib` then reinstall gettext `brew reinstall gettext` to fix the issue.


### PR DESCRIPTION
Device: Mac Os 14.0  (sonoma) Apple M1 Pro
Issue: Resizing Disk Error and Library Not Loaded 

Context:
- When attempting to resize the Alpine disk, an error message is displayed, for example: unable to resize disk: signal: abort trap.
- The resizing operation internally utilizes the qemu-img resize <IMAGE_LOCATION> <+SIZE> command.
- If the qemu-img resize command produces an error message like dyld[28316]: Library not loaded: /opt/homebrew/opt/libunistring/lib/libunistring.2.dylib, this indicates a library issue.
- `brew reinstall gettext` fixes the library issue.