### PR TITLE
Check for bad filenames in tar archive expansion in utils/utils.go

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -166,6 +166,9 @@ func Uncompress(source string, destination string) error {
 		} else if err != nil {
 			return err
 		}
+      if strings.Contains(string(cur.Name), "..") {
+         return fmt.Errorf("archive contains invalid filename: %s", cur.Name)
+      }
 
 		os.MkdirAll(destination, 0777)
 


### PR DESCRIPTION
Closes #167 