### PR TITLE
add express start option

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -27,6 +27,7 @@ var launchCmd = &cobra.Command{
 }
 
 var machineArch, imageVersion, machineCPU, machineMemory, machineDisk, machinePort, sshPort, machineName, machineMount string
+var expressStart bool
 
 func init() {
 	includeLaunchFlags(launchCmd)
@@ -42,6 +43,7 @@ func includeLaunchFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&sshPort, "ssh", "s", "22", "Host port to forward for SSH (required).")
 	cmd.Flags().StringVarP(&machinePort, "port", "p", "", "Forward additional host ports. Multiple ports can be separated by `,`.")
 	cmd.Flags().StringVarP(&machineName, "name", "n", "", "Instance name for use in `alpine` commands.")
+	cmd.Flags().BoolVarP(&expressStart, "express", "e", false, "Start instance in express mode. SSH connection and pre-flight checks are not carried out.")
 }
 
 func CorrectArguments(imageVersion string, machineArch string, machineCPU string,
@@ -149,19 +151,20 @@ func launch(cmd *cobra.Command, args []string) {
 	}
 
 	machineConfig := qemu.MachineConfig{
-		Alias:       machineName,
-		Image:       imageVersion + "-" + machineArch + ".qcow2",
-		Arch:        machineArch,
-		CPU:         machineCPU,
-		Memory:      machineMemory,
-		Disk:        machineDisk,
-		Mount:       machineMount,
-		Port:        machinePort,
-		SSHPort:     sshPort,
-		MACAddress:  macAddress,
-		SSHUser:     "root",
-		SSHPassword: "raw::root",
-		Tags:        []string{},
+		Alias:        machineName,
+		Image:        imageVersion + "-" + machineArch + ".qcow2",
+		Arch:         machineArch,
+		CPU:          machineCPU,
+		Memory:       machineMemory,
+		Disk:         machineDisk,
+		Mount:        machineMount,
+		Port:         machinePort,
+		SSHPort:      sshPort,
+		ExpressStart: expressStart,
+		MACAddress:   macAddress,
+		SSHUser:      "root",
+		SSHPassword:  "raw::root",
+		Tags:         []string{},
 	}
 	machineConfig.Location = filepath.Join(userHomeDir, ".macpine", machineConfig.Alias)
 

--- a/qemu/ops.go
+++ b/qemu/ops.go
@@ -29,6 +29,7 @@ type MachineConfig struct {
 	Disk         string   `yaml:"disk"`
 	Mount        string   `yaml:"mount"`
 	Port         string   `yaml:"port"`
+	ExpressStart bool     `yaml:"expressstart"`
 	SSHPort      string   `yaml:"sshport"`
 	SSHUser      string   `yaml:"sshuser"`
 	SSHPassword  string   `yaml:"sshpassword"`
@@ -434,12 +435,15 @@ func (c *MachineConfig) Start() error {
 		return err
 	}
 
-	log.Println("awaiting ssh server...")
-	err = c.Exec("hwclock -s", true) // root=true i.e. run as root
-	if err != nil {
-		c.Stop()
-		c.CleanPIDFile()
-		return err
+	if !c.ExpressStart {
+		log.Println("awaiting ssh server...")
+
+		err = c.Exec("hwclock -s", true) // root=true i.e. run as root
+		if err != nil {
+			c.Stop()
+			c.CleanPIDFile()
+			return err
+		}
 	}
 
 	if c.Mount != "" {


### PR DESCRIPTION
Adds an option to express launch a VM - default behaviour is false.

If true, the VM is launched without trying to execute pre-flight checks e.g. syncing system and vm clock.

This drastically speeds up the start speed of a VM with ssh still being available.